### PR TITLE
Fix multiple same-type blocks in panel (fixes #19)

### DIFF
--- a/lib/panel.js
+++ b/lib/panel.js
@@ -40,7 +40,7 @@ class Panel {
 	}
 
 	update() {
-		const uniqueParts = $.unique(this.parts.slice(0)).map((name) => ({
+		const uniqueParts = this.parts.filter((name, i) => this.parts.indexOf(name) === i).map((name) => ({
 			count: this.parts.filter((part) => name === part).length,
 			name: name,
 		}));


### PR DESCRIPTION
Safariにおいて下部のパネル内に同じタイプのブロックが複数現れる現象を解消しました（jQuery.uniqueはDOM要素に対してしか使えないらしいので自前のuniqueにしました）