### PR TITLE
データの流れがなくなると止まるようにしました

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -122,6 +122,19 @@ class Board extends EventEmitter {
 
 		if (this.datas.length === 0) {
 			this.halt();
+		} else {
+			let noOutput = true;
+			this.forBlocks((block) => {
+				for (let source in block.outputQueues) {
+					if (block.outputQueues[source].length > 0) {
+						noOutput = false;
+						break;
+					}
+				}
+			});
+			if (noOutput) {
+				this.halt();
+			}
 		}
 	}
 


### PR DESCRIPTION
すべてのデータが2項演算子などの手前で止まってしまった場合に操作不能になる問題 (Issue #26) があったので，データの流れが止まったとき（=どのブロックからもデータが出てこないとき）に halt するようにしました