### PR TITLE
データの流れがなくなったときにデータが消えないようにしました

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -11,6 +11,7 @@ class Board extends EventEmitter {
 		this.width = config.width;
 
 		this.executing = false;
+		this.paused = false;
 		this.clock = 0;
 
 		this.blocks = [];
@@ -99,6 +100,7 @@ class Board extends EventEmitter {
 		});
 
 		this.executing = true;
+		this.paused = false;
 		this.clock = 0;
 		return inputData;
 	}
@@ -148,12 +150,14 @@ class Board extends EventEmitter {
 
 	halt() {
 		this.executing = false;
+		this.paused = false;
 		this.clearData();
 		this.emit('halt');
 	}
 
 	pause() {
-		this.executing = false;
+		this.paused = true;
+		this.emit('paused');
 	}
 }
 

--- a/lib/board.js
+++ b/lib/board.js
@@ -133,7 +133,7 @@ class Board extends EventEmitter {
 				}
 			});
 			if (noOutput) {
-				this.halt();
+				this.pause();
 			}
 		}
 	}
@@ -150,6 +150,10 @@ class Board extends EventEmitter {
 		this.executing = false;
 		this.clearData();
 		this.emit('halt');
+	}
+
+	pause() {
+		this.executing = false;
 	}
 }
 

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -92,12 +92,12 @@ class Stage {
 		this.board.step();
 		this.$stage.find('.clock-num').text(this.board.clock);
 
-		if (this.board.executing) {
+		if (this.board.executing && !this.board.paused) {
 			Promise.all(this.boardElement.animations).then(() => {
 				this.boardElement.animations = [];
 				this.board.pass();
 
-				if (this.board.executing) {
+				if (this.board.executing && !this.board.paused) {
 					this.clockUp();
 				}
 			});


### PR DESCRIPTION
#29 で流れがなくなった時に halt するようにしたのですがデータが突然消えるのはよくない（確かに）ので Board::executing を false にするだけにしました。データは盤面上に残り，stop ボタンが表示されたままになります。stop ボタンを押せばデータは消えます。