### PR TITLE
ブロックの個数をクリックできないように

### DIFF
--- a/index.less
+++ b/index.less
@@ -870,6 +870,8 @@ button {
 				font-weight: 900;
 				color: darkred;
 
+				pointer-events: none;
+
 				&::before {
 					content: 'x';
 				}


### PR DESCRIPTION
パネル内のブロックの個数（x99 とか）をクリックするとブロック選択が解除されるようになっていたので、クリックできないようにしました。