### PR TITLE
Update node version of Travis to the latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 6
+  - node
 
 # https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
 addons:


### PR DESCRIPTION
The blocking issue of node-sqlite3 (https://github.com/mapbox/node-sqlite3/issues/728) seems to be resolved.