### PR TITLE
算術ブロックを追加

### DIFF
--- a/index.less
+++ b/index.less
@@ -1148,8 +1148,8 @@ button {
 			transform: rotate(270deg);
 		}
 		@blocks-rotatable: wireI, wireL, wireT, diode;
-		@blocks-rotate-back-wireI: times-2, add-3, times-3, plus-1, plus-2, minus-1, minus-2, div-2, div-3, const-0, const-1, const-2;
-		@blocks-norotate: wireXdot, add, sub, mul, div,  c-contact, conditional, transistor, wireX, pow, mod, bitshift-left, bitshift-right, bitwise-and, bitwise-or, bitwise-xor, equal, neq, gt, geqq, lt, leqq;
+		@blocks-rotate-back-wireI: times-2, add-3, times-3, times-10, plus-1, plus-2, minus-1, minus-2, div-2, div-3, div-10, const-0, const-1, const-2, const-3, const-10, log10, log2;
+		@blocks-norotate: wireXdot, add, sub, mul, div,  c-contact, conditional, transistor, wireX, pow, log, mod, bitshift-left, bitshift-right, bitwise-and, bitwise-or, bitwise-xor, equal, neq, gt, geqq, lt, leqq;
 
 		.-r(@i: length(@blocks-rotatable)) when (@i > 0) {
 			@name: extract(@blocks-rotatable, @i);

--- a/lib/block-configs.js
+++ b/lib/block-configs.js
@@ -58,6 +58,15 @@ module.exports = {
 		weight: 2,
 		rotatable: true,
 	},
+	'times-10': {
+		type: 'calc',
+		func: (n) => n * 10,
+		io: {
+			plugs: ['top', 'bottom'],
+		},
+		weight: 2,
+		rotatable: true,
+	},
 	'add-3': {
 		type: 'calc',
 		func: (n) => n + 3,
@@ -113,9 +122,36 @@ module.exports = {
 		weight: 2,
 		rotatable: true,
 	},
+	'div-10': {
+		type: 'calc',
+		func: (n) => (n - n % 10) / 10,
+		io: {
+			plugs: ['top', 'bottom'],
+		},
+		weight: 2,
+		rotatable: true,
+	},
 	'minus-2': {
 		type: 'calc',
 		func: (n) => n - 2,
+		io: {
+			plugs: ['top', 'bottom'],
+		},
+		weight: 2,
+		rotatable: true,
+	},
+	'log10': {
+		type: 'calc',
+		func: (n) => Math.floor(Math.log10(n)),
+		io: {
+			plugs: ['top', 'bottom'],
+		},
+		weight: 2,
+		rotatable: true,
+	},
+	'log2': {
+		type: 'calc',
+		func: (n) => Math.floor(Math.log2(n)),
 		io: {
 			plugs: ['top', 'bottom'],
 		},
@@ -143,6 +179,24 @@ module.exports = {
 	'const-2': {
 		type: 'calc',
 		func: () => 2,
+		io: {
+			plugs: ['top', 'bottom'],
+		},
+		weight: 2,
+		rotatable: true,
+	},
+	'const-3': {
+		type: 'calc',
+		func: () => 3,
+		io: {
+			plugs: ['top', 'bottom'],
+		},
+		weight: 2,
+		rotatable: true,
+	},
+	'const-10': {
+		type: 'calc',
+		func: () => 10,
 		io: {
 			plugs: ['top', 'bottom'],
 		},
@@ -202,6 +256,15 @@ module.exports = {
 	pow: {
 		type: 'calc2',
 		func: (a, b) => parseInt(Math.pow(a, b)),
+		io: {
+			in: ['left', 'right'],
+			out: 'bottom',
+		},
+		weight: 3,
+	},
+	log: {
+		type: 'calc2',
+		func: (a, b) => Math.floor(Math.log(b) / Math.log(a)),
 		io: {
 			in: ['left', 'right'],
 			out: 'bottom',

--- a/lib/block-configs.js
+++ b/lib/block-configs.js
@@ -142,7 +142,7 @@ module.exports = {
 	},
 	log10: {
 		type: 'calc',
-		func: (n) => Math.floor(Math.log10(n) + Number.EPSILON * 5),
+		func: (n) => Math.floor(Math.log10(Math.abs(n)) + Number.EPSILON * 5),
 		io: {
 			plugs: ['top', 'bottom'],
 		},
@@ -151,7 +151,7 @@ module.exports = {
 	},
 	log2: {
 		type: 'calc',
-		func: (n) => Math.floor(Math.log2(n) + Number.EPSILON * 5),
+		func: (n) => Math.floor(Math.log2(Math.abs(n)) + Number.EPSILON * 5),
 		io: {
 			plugs: ['top', 'bottom'],
 		},
@@ -264,7 +264,7 @@ module.exports = {
 	},
 	log: {
 		type: 'calc2',
-		func: (a, b) => Math.floor(Math.log(b) / Math.log(a) + Number.EPSILON * 5),
+		func: (a, b) => Math.floor(Math.log(Math.abs(b)) / Math.log(Math.abs(a)) + Number.EPSILON * 5),
 		io: {
 			in: ['left', 'right'],
 			out: 'bottom',

--- a/lib/block-configs.js
+++ b/lib/block-configs.js
@@ -142,7 +142,7 @@ module.exports = {
 	},
 	'log10': {
 		type: 'calc',
-		func: (n) => Math.floor(Math.log10(n)),
+		func: (n) => Math.floor(Math.log10(n) + Number.EPSILON * 5),
 		io: {
 			plugs: ['top', 'bottom'],
 		},
@@ -151,7 +151,7 @@ module.exports = {
 	},
 	'log2': {
 		type: 'calc',
-		func: (n) => Math.floor(Math.log2(n)),
+		func: (n) => Math.floor(Math.log2(n) + Number.EPSILON * 5),
 		io: {
 			plugs: ['top', 'bottom'],
 		},
@@ -264,7 +264,7 @@ module.exports = {
 	},
 	log: {
 		type: 'calc2',
-		func: (a, b) => Math.floor(Math.log(b) / Math.log(a)),
+		func: (a, b) => Math.floor(Math.log(b) / Math.log(a) + Number.EPSILON * 5),
 		io: {
 			in: ['left', 'right'],
 			out: 'bottom',

--- a/lib/block-configs.js
+++ b/lib/block-configs.js
@@ -255,7 +255,12 @@ module.exports = {
 	},
 	pow: {
 		type: 'calc2',
-		func: (a, b) => parseInt(Math.pow(a, b)),
+		func: (a, b) => {
+			if (a === 1 && (b === Infinity || b === -Infinity)) {
+				return 1;
+			}
+			return parseInt(Math.pow(a, b));
+		},
 		io: {
 			in: ['left', 'right'],
 			out: 'bottom',

--- a/lib/block-configs.js
+++ b/lib/block-configs.js
@@ -140,7 +140,7 @@ module.exports = {
 		weight: 2,
 		rotatable: true,
 	},
-	'log10': {
+	log10: {
 		type: 'calc',
 		func: (n) => Math.floor(Math.log10(n) + Number.EPSILON * 5),
 		io: {
@@ -149,7 +149,7 @@ module.exports = {
 		weight: 2,
 		rotatable: true,
 	},
-	'log2': {
+	log2: {
 		type: 'calc',
 		func: (n) => Math.floor(Math.log2(n) + Number.EPSILON * 5),
 		io: {

--- a/lib/block.js
+++ b/lib/block.js
@@ -133,7 +133,8 @@ class Block extends EventEmitter {
 
 					const output = new Map();
 					destinations.forEach((direction) => {
-						const outData = new Data(this.board, this.config.func(data.value));
+						const value = this.config.func(data.value);
+						const outData = new Data(this.board, isNaN(value) ? 0 : value);
 						this.outputQueues.get(direction).push(outData);
 						output.set(direction, outData);
 					});
@@ -165,10 +166,8 @@ class Block extends EventEmitter {
 					datas.push(data);
 				});
 
-				const outData = new Data(
-					this.board,
-					this.config.func(...datas.map((data) => data.value))
-				);
+				const value = this.config.func(...datas.map((data) => data.value));
+				const outData = new Data(this.board, isNaN(value) ? 0 : value);
 				this.outputQueues.get(destination).push(outData);
 				const output = new Map([[destination, outData]]);
 
@@ -207,7 +206,7 @@ class Block extends EventEmitter {
 				const values = datas.map((data) => data.value);
 				const [directionIndex, value] = this.config.func(...values);
 
-				const data = new Data(this.board, value);
+				const data = new Data(this.board, isNaN(value) ? 0 : value);
 				const destination = destinations[directionIndex];
 				this.outputQueues.get(destination).push(data);
 				const output = new Map([[destination, data]]);

--- a/stages/mod3-hard.yml
+++ b/stages/mod3-hard.yml
@@ -10,12 +10,18 @@ parts:
   minus-2: null
   times-2: null
   times-3: null
+  times-10: null
+  log10: null
+  log2: null
   const-0: null
   const-1: null
   const-2: null
+  const-3: null
+  const-10: null
   add: null
   sub: null
   pow: null
+  log: null
   equal: null
   neq: null
   gt: null

--- a/stages/the-fifth-max.yml
+++ b/stages/the-fifth-max.yml
@@ -6,21 +6,28 @@ parts:
   wireX: null
   times-2: null
   times-3: null
+  times-10: null
   div-2: null
   div-3: null
+  div-10: null
   plus-1: null
   plus-2: null
   minus-1: null
   minus-2: null
+  log10: null
+  log2: null
   const-0: null
   const-1: null
   const-2: null
+  const-3: null
+  const-10: null
   add: null
   sub: null
   div: null
   mul: null
   mod: null
   pow: null
+  log: null
   bitshift-left: null
   bitshift-right: null
   bitwise-and: null
@@ -53,34 +60,34 @@ input:
       - -1
       - 2
       - -2
-  - - 7 
-    - - 51 
-      - 90 
-      - 20 
-      - 30 
-      - 1 
-      - 60 
-      - 81 
-  - - 7 
-    - - 67 
+  - - 7
+    - - 51
+      - 90
+      - 20
+      - 30
+      - 1
+      - 60
+      - 81
+  - - 7
+    - - 67
       - 90
       - 46
-      - 99 
-      - 59 
-      - 23 
-      - 66 
-  - - 7 
-    - - 22 
+      - 99
+      - 59
+      - 23
+      - 66
+  - - 7
+    - - 22
       - 89
       - 48
       - 20
-      - 88 
+      - 88
       - 39
-      - 22 
+      - 22
 output:
   - 3
   - 0
-  - 51 
+  - 51
   - 66
   - 39
 width: 31

--- a/test/unit/block.ls
+++ b/test/unit/block.ls
@@ -281,6 +281,12 @@ describe 'Block' ->
         in: top: 1000
         out: bottom: 3
 
+    It 'ignores sign of input data' ->
+      io-test do
+        type: \log10
+        in: top: -334
+        out: bottom: 2
+
   describe 'log2 block' ->
     It 'converts data into the logarithm of it with base 2' ->
       io-test do
@@ -292,6 +298,12 @@ describe 'Block' ->
       io-test do
         type: \log2
         in: top: 334
+        out: bottom: 8
+
+    It 'ignores sign of input data' ->
+      io-test do
+        type: \log2
+        in: top: -334
         out: bottom: 8
 
   describe 'const-0 block' ->
@@ -459,3 +471,12 @@ describe 'Block' ->
           right: 0
         out:
           bottom: -Infinity
+
+    It 'ignores signs of input data' ->
+      io-test do
+        type: \log
+        in:
+          left: -4
+          right: -33
+        out:
+          bottom: 2

--- a/test/unit/block.ls
+++ b/test/unit/block.ls
@@ -426,6 +426,7 @@ describe 'Block' ->
           right: -3
         out:
           bottom: 0
+
     It 'deletes numbers after the decimal point' ->
       io-test do
         type: \pow
@@ -434,6 +435,15 @@ describe 'Block' ->
           right: -3
         out:
           bottom: 0
+
+    It 'returns 1 when left is 1 and right is an infinity' ->
+      io-test do
+        type: \pow
+        in:
+          left: 1
+          right: Infinity
+        out:
+          bottom: 1
 
   describe 'log block' ->
     It 'sends to bottom the logarithm of right with base of left' ->

--- a/test/unit/block.ls
+++ b/test/unit/block.ls
@@ -170,6 +170,13 @@ describe 'Block' ->
         in: top: 334
         out: bottom: 1002
 
+  describe 'times-10 block' ->
+    It 'converts data by multiplying 10' ->
+      io-test do
+        type: \times-10
+        in: top: 334
+        out: bottom: 3340
+
   describe 'plus-1 block' ->
     It 'converts data by adding 1' ->
       io-test do
@@ -222,6 +229,25 @@ describe 'Block' ->
         in: top: -17
         out: bottom: -5
 
+  describe 'div-10 block' ->
+    It 'converts data by dividing by 10' ->
+      io-test do
+        type: \div-10
+        in: top: 330
+        out: bottom: 33
+
+    It 'omits remainder of the division' ->
+      io-test do
+        type: \div-10
+        in: top: 334
+        out: bottom: 33
+
+    It 'rounds remainder into zero' ->
+      io-test do
+        type: \div-10
+        in: top: -334
+        out: bottom: -33
+
   describe 'minus-1 block' ->
     It 'converts data by subtracting 1' ->
       io-test do
@@ -235,6 +261,38 @@ describe 'Block' ->
         type: \minus-2
         in: top: 334
         out: bottom: 332
+
+  describe 'log10 block' ->
+    It 'converts data into the logarithm of it with base 10' ->
+      io-test do
+        type: \log10
+        in: top: 100
+        out: bottom: 2
+
+    It 'truncates decimal places' ->
+      io-test do
+        type: \log10
+        in: top: 334
+        out: bottom: 2
+
+    It 'calculates log_10 1000 correctly' ->
+      io-test do
+        type: \log10
+        in: top: 1000
+        out: bottom: 3
+
+  describe 'log2 block' ->
+    It 'converts data into the logarithm of it with base 2' ->
+      io-test do
+        type: \log2
+        in: top: 1024
+        out: bottom: 10
+
+    It 'truncates decimal places' ->
+      io-test do
+        type: \log2
+        in: top: 334
+        out: bottom: 8
 
   describe 'const-0 block' ->
     It 'converts any input data into 0' ->
@@ -256,6 +314,20 @@ describe 'Block' ->
         type: \const-2
         in: top: 334
         out: bottom: 2
+
+  describe 'const-3 block' ->
+    It 'converts any input data into 3' ->
+      io-test do
+        type: \const-3
+        in: top: 334
+        out: bottom: 3
+
+  describe 'const-10 block' ->
+    It 'converts any input data into 10' ->
+      io-test do
+        type: \const-10
+        in: top: 334
+        out: bottom: 10
 
   describe 'add block' ->
     It 'adds up left and right and send it to bottom' ->
@@ -323,6 +395,7 @@ describe 'Block' ->
           right: -0
         out:
           bottom: -Infinity
+
   describe 'pow block' ->
     It 'powers left by right and send it to bottom' ->
       io-test do
@@ -350,3 +423,39 @@ describe 'Block' ->
         out:
           bottom: 0
 
+  describe 'log block' ->
+    It 'sends to bottom the logarithm of right with base of left' ->
+      io-test do
+        type: \log
+        in:
+          left: 3
+          right: 81
+        out:
+          bottom: 4
+
+    It 'truncates decimal places' ->
+      io-test do
+        type: \log
+        in:
+          left: 4
+          right: 33
+        out:
+          bottom: 2
+
+    It 'calculates log_10 1000 correctly' ->
+      io-test do
+        type: \log
+        in:
+          left: 10
+          right: 1000
+        out:
+          bottom: 3
+
+    It 'returns -Infinity when right is 0' ->
+      io-test do
+        type: \log
+        in:
+          left: 334
+          right: 0
+        out:
+          bottom: -Infinity


### PR DESCRIPTION
Close #143.

----

といきたいところでしたが……
```js
> Math.log(1000) / Math.log(10)
2.9999999999999996
> Math.floor(Math.log(1000) / Math.log(10))
2
```
（つらい）

（log10ブロックは `Math.log10` を使っているのですが環境によって [core-jsのMath.log10](https://github.com/zloirock/core-js/blob/v2.4.1/modules/es6.math.log10.js) が使われるかもしれないのでやはりつらい）