### PR TITLE
ステージをバージョニング可能に

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
 script:
   - npm run build:production
   - npm test
-  - npm run test:api:init
   - npm run test:api
 after_success:
   - npm run coveralls

--- a/api/README.md
+++ b/api/README.md
@@ -17,6 +17,5 @@ npm run api
 ## テスト実行
 
 ```
-npm run test:api:init
 npm run test:api
 ```

--- a/api/config/config.json
+++ b/api/config/config.json
@@ -9,7 +9,7 @@
     "username": "",
     "password": "",
     "dialect": "sqlite",
-    "storage": "db-test.sqlite3"
+    "storage": ":memory:"
   },
   "production": {
     "use_env_variable": "DATABASE_URL"

--- a/api/config/config.json
+++ b/api/config/config.json
@@ -9,7 +9,8 @@
     "username": "",
     "password": "",
     "dialect": "sqlite",
-    "storage": ":memory:"
+    "storage": ":memory:",
+    "logging": false
   },
   "production": {
     "use_env_variable": "DATABASE_URL"

--- a/api/migrations/20161202090513-add-version-column.js
+++ b/api/migrations/20161202090513-add-version-column.js
@@ -1,13 +1,23 @@
 module.exports = {
 	up: (queryInterface, Sequelize) => (
-		queryInterface.addColumn('submissions', 'version', {
-			type: Sequelize.INTEGER,
-			allowNull: false,
-			defaultValue: 1,
-		})
+		Promise.all([
+			queryInterface.addColumn('stages', 'version', {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+				defaultValue: 1,
+			}),
+			queryInterface.addColumn('submissions', 'version', {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+				defaultValue: 1,
+			}),
+		])
 	),
 
 	down: (queryInterface) => (
-		queryInterface.removeColumn('submissions', 'version')
+		Promise.all([
+			queryInterface.removeColumn('stages', 'version'),
+			queryInterface.removeColumn('submissions', 'version'),
+		])
 	),
 };

--- a/api/migrations/20161202090513-add-version-column.js
+++ b/api/migrations/20161202090513-add-version-column.js
@@ -1,0 +1,13 @@
+module.exports = {
+	up: (queryInterface, Sequelize) => (
+		queryInterface.addColumn('submissions', 'version', {
+			type: Sequelize.INTEGER,
+			allowNull: false,
+			defaultValue: 1,
+		})
+	),
+
+	down: (queryInterface) => (
+		queryInterface.removeColumn('submissions', 'version')
+	),
+};

--- a/api/migrations/20161202090513-add-version-column.js
+++ b/api/migrations/20161202090513-add-version-column.js
@@ -1,7 +1,7 @@
 module.exports = {
 	up: (queryInterface, Sequelize) => (
 		Promise.all([
-			queryInterface.addColumn('stages', 'version', {
+			queryInterface.addColumn('stages', 'migratedVersion', {
 				type: Sequelize.INTEGER,
 				allowNull: false,
 				defaultValue: 1,
@@ -16,7 +16,7 @@ module.exports = {
 
 	down: (queryInterface) => (
 		Promise.all([
-			queryInterface.removeColumn('stages', 'version'),
+			queryInterface.removeColumn('stages', 'migratedVersion'),
 			queryInterface.removeColumn('submissions', 'version'),
 		])
 	),

--- a/api/models/stage.js
+++ b/api/models/stage.js
@@ -3,6 +3,14 @@ const sequelize = require('./');
 
 const Stage = sequelize.define('stages', {
 	name: Sequelize.TEXT,
+	migratedVersion: {
+		type: Sequelize.INTEGER,
+		allowNull: false,
+		defaultValue: 1,
+		validate: {
+			min: 1,
+		},
+	},
 });
 
 module.exports = Stage;

--- a/api/models/submission.js
+++ b/api/models/submission.js
@@ -43,6 +43,14 @@ const Submission = sequelize.define('submissions', {
 			key: 'id',
 		},
 	},
+	version: {
+		type: Sequelize.INTEGER,
+		allowNull: false,
+		defaultValue: 1,
+		validate: {
+			min: 1,
+		},
+	},
 });
 
 Submission.belongsTo(Stage);

--- a/api/routes/stages.js
+++ b/api/routes/stages.js
@@ -39,7 +39,12 @@ router.get('/:stage/submissions', (req, res) => {
 	Submissions.findAll({
 		include: [{
 			model: Stages,
-			where: {name: stageName},
+			where: {
+				name: stageName,
+				migratedVersion: {
+					$col: 'submissions.version',
+				},
+			},
 		}],
 		order: [
 			['score', 'DESC'],
@@ -113,7 +118,7 @@ router.post('/:stage/submissions', (req, res) => {
 		});
 
 		if (existingSubmission) {
-			if (score <= existingSubmission.score) {
+			if (score <= existingSubmission.score && stageDatum.version <= existingSubmission.version) {
 				res.status(400).json({
 					error: true,
 					message: 'user name existing',
@@ -127,6 +132,7 @@ router.post('/:stage/submissions', (req, res) => {
 				score,
 				blocks,
 				clocks,
+				version: stageDatum.version,
 				stageId: stage.id,
 			}, {
 				where: {
@@ -157,6 +163,7 @@ router.post('/:stage/submissions', (req, res) => {
 				score,
 				blocks,
 				clocks,
+				version: stageDatum.version,
 				stageId: stage.id,
 			}).then((submission) => {
 				res.json(submission);

--- a/api/routes/stages.js
+++ b/api/routes/stages.js
@@ -89,82 +89,83 @@ router.post('/:stage/submissions', (req, res) => {
 				error: true,
 				message: 'stage not found',
 			});
-		} else {
-			submissionData.stage = stageName;
+			return;
+		}
 
-			const {pass, message, blocks, clocks} = validateSubmission(submissionData);
+		submissionData.stage = stageName;
 
-			if (!pass) {
+		const {pass, message, blocks, clocks} = validateSubmission(submissionData);
+
+		if (!pass) {
+			res.status(400).json({
+				error: true,
+				message,
+			});
+			return;
+		}
+
+		const stageDatum = stageData.find((s) => s.name === stageName);
+
+		const score = calculateScore({
+			clocks,
+			blocks,
+			stage: stageDatum,
+		});
+
+		if (existingSubmission) {
+			if (score <= existingSubmission.score) {
 				res.status(400).json({
 					error: true,
-					message,
+					message: 'user name existing',
 				});
 				return;
 			}
 
-			const stageDatum = stageData.find((s) => s.name === stageName);
-
-			const score = calculateScore({
-				clocks,
+			Submissions.update({
+				name: req.body.name,
+				board: JSON.stringify(req.body.board),
+				score,
 				blocks,
-				stage: stageDatum,
-			});
-
-			if (existingSubmission) {
-				if (score <= existingSubmission.score) {
-					res.status(400).json({
-						error: true,
-						message: 'user name existing',
-					});
-					return;
-				}
-
-				Submissions.update({
+				clocks,
+				stageId: stage.id,
+			}, {
+				where: {
 					name: req.body.name,
-					board: JSON.stringify(req.body.board),
-					score,
-					blocks,
-					clocks,
 					stageId: stage.id,
-				}, {
+				},
+			}).then(([count]) => {
+				assert.strictEqual(count, 1);
+				return Submissions.findOne({
 					where: {
 						name: req.body.name,
 						stageId: stage.id,
 					},
-				}).then(([count]) => {
-					assert.strictEqual(count, 1);
-					return Submissions.findOne({
-						where: {
-							name: req.body.name,
-							stageId: stage.id,
-						},
-					});
-				}).then((submission) => {
-					res.json(submission);
-				}).catch((error) => {
-					res.status(500).json({
-						error: true,
-						message: error.message,
-					});
 				});
-			} else {
-				// If no previous submission is existing
-				Submissions.create({
-					name: req.body.name,
-					board: JSON.stringify(req.body.board),
-					score,
-					blocks,
-					clocks,
-					stageId: stage.id,
-				}).then((submission) => {
-					res.json(submission);
-				}).catch((error) => {
-					res.status(500).json({
-						error: true,
-						message: error.message,
-					});
+			}).then((submission) => {
+				res.json(submission);
+			}).catch((error) => {
+				res.status(500).json({
+					error: true,
+					message: error.message,
 				});
-			}
+			});
+		} else {
+			// If no previous submission is existing
+			Submissions.create({
+				name: req.body.name,
+				board: JSON.stringify(req.body.board),
+				score,
+				blocks,
+				clocks,
+				stageId: stage.id,
+			}).then((submission) => {
+				res.json(submission);
+			}).catch((error) => {
+				res.status(500).json({
+					error: true,
+					message: error.message,
+				});
+			});
 		}
 	});
 });

--- a/api/scripts/migrateStages.js
+++ b/api/scripts/migrateStages.js
@@ -1,0 +1,92 @@
+/* eslint no-console: 'off' */
+
+// ステージのバージョンを変更した場合にランキングをマイグレートするスクリプト
+// TODO: ステージを追加・削除した場合に対応
+
+const assert = require('assert');
+const Promise = require('bluebird');
+const sequelize = require('../models');
+const Stages = require('../models/stage');
+const Submissions = require('../models/submission');
+const stageData = require('../../stages');
+const {validateSubmission, calculateScore} = require('../../lib/validator');
+
+sequelize.transaction((transaction) => {
+	// Get all stages
+	console.log('Getting stages...');
+
+	return Stages.findAll({transaction}).then((stages) => {
+		console.log(`Got ${stages.length} stages`);
+
+		// Find stages which needs migration
+		const migratingStages = stages.filter((stage) => {
+			const stageDatum = stageData.find((tempStage) => tempStage.name === stage.name);
+			assert.notStrictEqual(typeof stageDatum, 'undefined');
+
+			if (stage.migratedVersion < stageDatum.version) {
+				return true;
+			}
+
+			return false;
+		});
+
+		console.log(`Migrating ${migratingStages.length} stages...`);
+
+		return Promise.each(migratingStages, (stage) => {
+			const stageDatum = stageData.find((tempStage) => tempStage.name === stage.name);
+
+			console.log(`Migrating "${stage.name}" stage... (version: ${stage.migratedVersion} => ${stageDatum.version})`);
+
+			return Submissions.findAll({
+				where: {
+					stageId: stage.id,
+					version: stage.migratedVersion,
+				},
+				transaction,
+			}).then((submissions) => {
+				console.log(`Migrating ${submissions.length} submissions...`);
+
+				return Promise.each(submissions, (submission) => {
+					console.log(`Validating submission from ${submission.name} of score ${submission.score}`);
+
+					const board = JSON.parse(submission.board);
+
+					console.time('validation');
+					const {pass, blocks, clocks} = validateSubmission({
+						board,
+						stage: stage.name,
+					});
+					console.timeEnd('validation');
+
+					if (!pass) {
+						console.log('Validation failed. Not updating version.');
+						return Promise.resolve();
+					}
+
+					const score = calculateScore({
+						clocks,
+						blocks,
+						stage: stageDatum,
+					});
+
+					console.log(`Validation Succeeded. (score: ${submission.score} => ${score})`);
+
+					return submission.update({
+						score,
+						blocks,
+						clocks,
+						version: stageDatum.version,
+					}, {transaction});
+				});
+			}).then(() => {
+				console.log(`Updating migratedVersion of "${stage.name}" stage...`);
+
+				return stage.update({
+					migratedVersion: stageDatum.version,
+				}, {transaction});
+			});
+		});
+	});
+}).then(() => {
+	console.log('done.');
+});

--- a/api/seeders/20161003085039-first-seed.js
+++ b/api/seeders/20161003085039-first-seed.js
@@ -4,6 +4,7 @@ module.exports = {
 	up: (queryInterface) => (
 		queryInterface.bulkInsert('stages', stages.map((stage, index) => ({
 			name: stage.name || `stage${index}`,
+			version: stage.version,
 			createdAt: new Date(),
 			updatedAt: new Date(),
 		})), {})

--- a/api/seeders/20161003085039-first-seed.js
+++ b/api/seeders/20161003085039-first-seed.js
@@ -4,7 +4,7 @@ module.exports = {
 	up: (queryInterface) => (
 		queryInterface.bulkInsert('stages', stages.map((stage, index) => ({
 			name: stage.name || `stage${index}`,
-			version: stage.version,
+			migratedVersion: stage.version,
 			createdAt: new Date(),
 			updatedAt: new Date(),
 		})), {})

--- a/api/seeders/20161003085039-first-seed.js
+++ b/api/seeders/20161003085039-first-seed.js
@@ -1,5 +1,4 @@
 const stages = require('../../stages');
-const Stages = require('../models/stage');
 
 module.exports = {
 	up: (queryInterface) => (
@@ -7,68 +6,7 @@ module.exports = {
 			name: stage.name || `stage${index}`,
 			createdAt: new Date(),
 			updatedAt: new Date(),
-		})), {}).then(() => (
-			Stages.findOne({where: {name: 'wire01'}})
-		)).then((stage) => {
-			if (process.env.NODE_ENV !== 'production') {
-				const board = JSON.stringify([{
-					x: 1,
-					y: 0,
-					name: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 1,
-					name: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 2,
-					name: 'wireI',
-					rotate: 0,
-				}]);
-
-				return queryInterface.bulkInsert('submissions', [{
-					name: 'kurgm',
-					board,
-					score: 9000,
-					blocks: 3,
-					clocks: 3,
-					stageId: stage.id,
-					createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
-					updatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
-				}, {
-					name: 'moratorium08',
-					board,
-					score: 10000,
-					blocks: 3,
-					clocks: 3,
-					stageId: stage.id,
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				}, {
-					name: 'Yosshi999',
-					board,
-					score: 9000,
-					blocks: 3,
-					clocks: 3,
-					stageId: stage.id,
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				}, {
-					name: 'hakatashi',
-					board,
-					score: 10000,
-					blocks: 3,
-					clocks: 3,
-					stageId: stage.id,
-					createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
-					updatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
-				}]);
-			}
-
-			return Promise.resolve();
-		})
+		})), {})
 	),
 
 	down: (queryInterface) => (

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -50,10 +50,13 @@ describe('/stages', () => {
 		it('retuns JSON of the stage array', () => (
 			Stages.bulkCreate([{
 				name: 'stage1',
+				version: 1,
 			}, {
 				name: 'stage2',
+				version: 2,
 			}, {
 				name: 'stage3',
+				version: 3,
 			}], {transaction}).then(() => (
 				chai.request(app).get('/stages')
 			)).then((res) => {
@@ -106,6 +109,7 @@ describe('/stages', () => {
 		it('retuns JSON of the submissions', () => (
 			Stages.create({
 				name: 'wire01',
+				version: 2,
 			}, {transaction}).then((stage) => (
 				Submissions.bulkCreate([{
 					name: 'kurgm',
@@ -172,6 +176,7 @@ describe('/stages', () => {
 		it('only lists submissions with latest version', () => (
 			Stages.create({
 				name: 'wire01',
+				version: 3,
 			}, {transaction}).then((stage) => (
 				Submissions.bulkCreate([{
 					name: 'gasin',
@@ -203,21 +208,13 @@ describe('/stages', () => {
 			)).then((res) => {
 				expect(res).to.have.status(200);
 				expect(res.body).to.have.length(1);
-				expect(res.body[0].name).to.equal('satos');
+				expect(res.body[0].name).to.equal('cookies');
 			})
 		));
 	});
 
 	describe('POST /stages/:stage/submissions', () => {
 		let stage = null;
-
-		beforeEach(() => (
-			Stages.create({
-				name: 'wire01',
-			}).then((newStage) => {
-				stage = newStage;
-			})
-		));
 
 		const validBoard = [{
 			x: 1,
@@ -257,6 +254,15 @@ describe('/stages', () => {
 			type: 'wireI',
 			rotate: 0,
 		}];
+
+		beforeEach(() => (
+			Stages.create({
+				name: 'wire01',
+				version: 1,
+			}).then((newStage) => {
+				stage = newStage;
+			})
+		));
 
 		it('creates new submission data if the submission is valid', () => (
 			chai.request(app).post('/stages/wire01/submissions').send({

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -105,7 +105,7 @@ describe('/stages', () => {
 			rotate: 0,
 		}]);
 
-		it('retuns JSON of the submissions', () => (
+		it('retuns JSON of the correctly ordered submissions', () => (
 			Stages.create({
 				name: 'wire01',
 				migratedVersion: 2,
@@ -208,6 +208,28 @@ describe('/stages', () => {
 				expect(res).to.have.status(200);
 				expect(res.body).to.have.length(1);
 				expect(res.body[0].name).to.equal('cookies');
+			})
+		));
+
+		it('limits returned submissions to 20', () => (
+			Stages.create({
+				name: 'wire01',
+				migratedVersion: 2,
+			}, {transaction}).then((stage) => (
+				Submissions.bulkCreate(Array.from({length: 100}, (item, index) => ({
+					name: `user${index}`,
+					board,
+					score: 10000,
+					blocks: 3,
+					clocks: 3,
+					stageId: stage.id,
+					version: 2,
+				})), {transaction})
+			)).then(() => (
+				chai.request(app).get('/stages/wire01/submissions')
+			)).then((res) => {
+				expect(res).to.have.status(200);
+				expect(res.body).to.have.length(20);
 			})
 		));
 	});

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -323,6 +323,17 @@ describe('/stages', () => {
 			})
 		));
 
+		it('rejects submission with empty name', () => (
+			chai.request(app).post('/stages/wire01/submissions').send({
+				name: '',
+				board: validBoard,
+			}).then(() => {
+				expect.fail();
+			}).catch((res) => {
+				expect(res).to.not.have.status(200);
+			})
+		));
+
 		it('updates record when the submission score is higher than existing one', () => (
 			chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'kurgm',

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -30,10 +30,8 @@ const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
 let transaction = null;
 
-// Execute migration
-before(() => (
-	umzug.up()
-));
+// Execute all migrations
+before(() => umzug.up());
 
 beforeEach(() => (
 	sequelize.transaction().then((newTransaction) => {
@@ -50,13 +48,13 @@ describe('/stages', () => {
 		it('retuns JSON of the stage array', () => (
 			Stages.bulkCreate([{
 				name: 'stage1',
-				version: 1,
+				migratedVersion: 1,
 			}, {
 				name: 'stage2',
-				version: 2,
+				migratedVersion: 2,
 			}, {
 				name: 'stage3',
-				version: 3,
+				migratedVersion: 3,
 			}], {transaction}).then(() => (
 				chai.request(app).get('/stages')
 			)).then((res) => {
@@ -77,6 +75,7 @@ describe('/stages', () => {
 		it('retuns JSON of the stage information', () => (
 			Stages.bulkCreate([{
 				name: 'wire01',
+				migratedVersion: 2,
 			}], {transaction}).then(() => (
 				chai.request(app).get('/stages/wire01')
 			)).then((res) => {
@@ -109,7 +108,7 @@ describe('/stages', () => {
 		it('retuns JSON of the submissions', () => (
 			Stages.create({
 				name: 'wire01',
-				version: 2,
+				migratedVersion: 2,
 			}, {transaction}).then((stage) => (
 				Submissions.bulkCreate([{
 					name: 'kurgm',
@@ -173,20 +172,12 @@ describe('/stages', () => {
 			})
 		));
 
-		it('only lists submissions with latest version', () => (
+		it('only lists submissions with the migrated version', () => (
 			Stages.create({
 				name: 'wire01',
-				version: 3,
+				migratedVersion: 3,
 			}, {transaction}).then((stage) => (
 				Submissions.bulkCreate([{
-					name: 'gasin',
-					board,
-					score: 10000,
-					blocks: 3,
-					clocks: 3,
-					stageId: stage.id,
-					version: 1,
-				}, {
 					name: 'satos',
 					board,
 					score: 10000,
@@ -202,6 +193,14 @@ describe('/stages', () => {
 					clocks: 3,
 					stageId: stage.id,
 					version: 3,
+				}, {
+					name: 'gasin',
+					board,
+					score: 10000,
+					blocks: 3,
+					clocks: 3,
+					stageId: stage.id,
+					version: 4,
 				}], {transaction})
 			)).then(() => (
 				chai.request(app).get('/stages/wire01/submissions')
@@ -258,7 +257,7 @@ describe('/stages', () => {
 		beforeEach(() => (
 			Stages.create({
 				name: 'wire01',
-				version: 1,
+				migratedVersion: 1,
 			}).then((newStage) => {
 				stage = newStage;
 			})

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -3,14 +3,30 @@
 
 const chai = require('chai');
 const chaiHttp = require('chai-http');
+const Umzug = require('umzug');
 const app = require('../../');
+const sequelize = require('../../models');
 const Submissions = require('../../models/submission');
+
+const umzug = new Umzug({
+	storage: 'sequelize',
+	storageOptions: {
+		sequelize,
+	},
+	migrations: {
+		params: [sequelize.getQueryInterface(), sequelize.constructor],
+	},
+});
 
 chai.use(chaiHttp);
 
 const expect = chai.expect;
 
 describe('/stages', () => {
+	before(() => (
+		umzug.up()
+	));
+
 	describe('GET /stages', () => {
 		it('retuns JSON of the stage array', () => (
 			chai.request(app).get('/stages').then((res) => {

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -165,31 +165,59 @@ describe('/stages', () => {
 	});
 
 	describe('POST /stages/:stage/submissions', () => {
+		let stage = null;
+
 		beforeEach(() => (
 			Stages.create({
 				name: 'wire01',
+			}).then((newStage) => {
+				stage = newStage;
 			})
 		));
+
+		const validBoard = [{
+			x: 1,
+			y: 0,
+			type: 'wireI',
+			rotate: 0,
+		}, {
+			x: 1,
+			y: 1,
+			type: 'wireI',
+			rotate: 0,
+		}, {
+			x: 1,
+			y: 2,
+			type: 'wireI',
+			rotate: 0,
+		}];
+
+		const lowerScoreBoard = [{
+			x: 1,
+			y: 0,
+			type: 'wireI',
+			rotate: 0,
+		}, {
+			x: 1,
+			y: 1,
+			type: 'wireI',
+			rotate: 0,
+		}, {
+			x: 0,
+			y: 1,
+			type: 'wireI',
+			rotate: 0,
+		}, {
+			x: 1,
+			y: 2,
+			type: 'wireI',
+			rotate: 0,
+		}];
 
 		it('creates new submission data if the submission is valid', () => (
 			chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'satos',
-				board: [{
-					x: 1,
-					y: 0,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 1,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 2,
-					type: 'wireI',
-					rotate: 0,
-				}],
+				board: validBoard,
 			}).then((res) => {
 				expect(res).to.have.status(200);
 				expect(res).to.be.json;
@@ -210,27 +238,14 @@ describe('/stages', () => {
 		it('reports error when the submission with higher score is existing', () => (
 			chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'hakatashi',
-				board: [{
-					x: 1,
-					y: 0,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 1,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 0,
-					y: 1,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 2,
-					type: 'wireI',
-					rotate: 0,
-				}],
+				board: validBoard,
+			}).then(() => (
+				chai.request(app).post('/stages/wire01/submissions').send({
+					name: 'hakatashi',
+					board: lowerScoreBoard,
+				})
+			)).then(() => {
+				expect.fail();
 			}).catch((res) => {
 				expect(res).to.have.status(400);
 			})
@@ -239,23 +254,13 @@ describe('/stages', () => {
 		it('updates record when the submission score is higher than existing one', () => (
 			chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'kurgm',
-				board: [{
-					x: 1,
-					y: 0,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 1,
-					type: 'wireI',
-					rotate: 0,
-				}, {
-					x: 1,
-					y: 2,
-					type: 'wireI',
-					rotate: 0,
-				}],
-			}).then((res) => {
+				board: lowerScoreBoard,
+			}).then(() => (
+				chai.request(app).post('/stages/wire01/submissions').send({
+					name: 'kurgm',
+					board: validBoard,
+				})
+			)).then((res) => {
 				expect(res).to.have.status(200);
 				expect(res).to.be.json;
 				expect(res.body.score).to.equal(10000);

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "sequelize-cli": "^2.4.0",
     "sqlite3": "^3.1.4",
     "uglifyify": "^3.0.3",
+    "umzug": "^1.11.0",
     "watchify": "^3.7.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "test": "npm run unit && npm run functional && npm run lint",
     "api:init": "cd api && sequelize db:migrate:undo:all && sequelize db:migrate && sequelize db:seed:all",
     "api": "cd api && node index.js",
-    "test:api:init": "cd api && cross-env NODE_ENV=test sequelize db:migrate:undo:all && cross-env NODE_ENV=test sequelize db:migrate && cross-env NODE_ENV=test sequelize db:seed:all",
     "test:api": "cd api && cross-env NODE_ENV=test istanbul cover ../node_modules/mocha/bin/_mocha -- --recursive"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
+    "bluebird": "^3.4.6",
     "browserify": "^13.0.1",
     "browserify-livescript": "^0.2.3",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
-    "bluebird": "^3.4.6",
     "browserify": "^13.0.1",
     "browserify-livescript": "^0.2.3",
     "chai": "^3.5.0",
@@ -89,6 +88,7 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
+    "bluebird": "^3.4.6",
     "body-parser": "^1.15.2",
     "core-js": "^2.4.1",
     "cors": "^2.8.1",

--- a/stages/100-again.yml
+++ b/stages/100-again.yml
@@ -1,4 +1,5 @@
 name: 100-again
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/100.yml
+++ b/stages/100.yml
@@ -1,4 +1,5 @@
 name: '100'
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/1000.yml
+++ b/stages/1000.yml
@@ -1,4 +1,5 @@
 name: '1000'
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/binarian-easy.yml
+++ b/stages/binarian-easy.yml
@@ -1,4 +1,5 @@
 name: binarian-easy
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/bivariation01.yml
+++ b/stages/bivariation01.yml
@@ -1,4 +1,5 @@
 name: bivariation01
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/calc01.yml
+++ b/stages/calc01.yml
@@ -1,4 +1,5 @@
 name: calc01
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/calc02.yml
+++ b/stages/calc02.yml
@@ -1,4 +1,5 @@
 name: calc02
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/calc03.yml
+++ b/stages/calc03.yml
@@ -1,4 +1,5 @@
 name: calc03
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/calc04.yml
+++ b/stages/calc04.yml
@@ -1,4 +1,5 @@
 name: calc04
+version: 1
 parts:
   wireI: null
   times-2: null

--- a/stages/calc05.yml
+++ b/stages/calc05.yml
@@ -1,4 +1,5 @@
 name: calc05
+version: 1
 parts:
   wireI: null
   times-2: 1

--- a/stages/calc06.yml
+++ b/stages/calc06.yml
@@ -1,4 +1,5 @@
 name: calc06
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/complement-of-2.yml
+++ b/stages/complement-of-2.yml
@@ -1,4 +1,5 @@
 name: complement-of-2
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/conditional01.yml
+++ b/stages/conditional01.yml
@@ -1,4 +1,5 @@
 name: conditional01
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/conditional02.yml
+++ b/stages/conditional02.yml
@@ -1,4 +1,5 @@
 name: conditional02
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/conditional03.yml
+++ b/stages/conditional03.yml
@@ -1,4 +1,5 @@
 name: conditional03
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/division-easy.yml
+++ b/stages/division-easy.yml
@@ -1,4 +1,5 @@
 name: division-easy
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/division-hard.yml
+++ b/stages/division-hard.yml
@@ -1,4 +1,5 @@
 name: division-hard
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/factorial.yml
+++ b/stages/factorial.yml
@@ -1,4 +1,5 @@
 name: factorial
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/fibonacci.yml
+++ b/stages/fibonacci.yml
@@ -1,4 +1,5 @@
 name: fibonacci
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/gcd.yml
+++ b/stages/gcd.yml
@@ -1,4 +1,5 @@
 name: gcd
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/lcm.yml
+++ b/stages/lcm.yml
@@ -1,4 +1,5 @@
 name: lcm
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/make-minus-one-easy.yml
+++ b/stages/make-minus-one-easy.yml
@@ -1,4 +1,5 @@
 name: make-minus-one-easy
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/make-minus-one-hard.yml
+++ b/stages/make-minus-one-hard.yml
@@ -1,4 +1,5 @@
 name: make-minus-one-hard
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/make-minus-one-med.yml
+++ b/stages/make-minus-one-med.yml
@@ -1,4 +1,5 @@
 name: make-minus-one-med
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/max.yml
+++ b/stages/max.yml
@@ -1,4 +1,5 @@
 name: max
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/mod3-hard.yml
+++ b/stages/mod3-hard.yml
@@ -1,4 +1,5 @@
 name: mod3-hard
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/msd.yml
+++ b/stages/msd.yml
@@ -1,4 +1,5 @@
 name: msd
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/parity.yml
+++ b/stages/parity.yml
@@ -1,4 +1,5 @@
 name: parity
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/perfect-number.yml
+++ b/stages/perfect-number.yml
@@ -1,4 +1,5 @@
 name: perfect-number
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/plus-32-hard.yml
+++ b/stages/plus-32-hard.yml
@@ -1,4 +1,5 @@
 name: plus-32-hard
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/plus-32.yml
+++ b/stages/plus-32.yml
@@ -1,4 +1,5 @@
 name: plus-32
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/power-easy.yml
+++ b/stages/power-easy.yml
@@ -1,4 +1,5 @@
 name: power-easy
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/power-hard.yml
+++ b/stages/power-hard.yml
@@ -1,4 +1,5 @@
 name: power-hard
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/remainder.yml
+++ b/stages/remainder.yml
@@ -1,4 +1,5 @@
 name: remainder
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/reversal.yml
+++ b/stages/reversal.yml
@@ -1,4 +1,5 @@
 name: reversal
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/sixth-power.yml
+++ b/stages/sixth-power.yml
@@ -1,4 +1,5 @@
 name: sixth-power
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/sqrt-easy.yml
+++ b/stages/sqrt-easy.yml
@@ -1,4 +1,5 @@
 name: sqrt-easy
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/sqrt-hard.yml
+++ b/stages/sqrt-hard.yml
@@ -1,4 +1,5 @@
 name: sqrt-hard
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/the-fifth-max.yml
+++ b/stages/the-fifth-max.yml
@@ -1,4 +1,5 @@
 name: the-fifth-max
+version: 1
 parts:
   wireI: null
   wireL: null

--- a/stages/wire01.yml
+++ b/stages/wire01.yml
@@ -1,4 +1,5 @@
 name: wire01
+version: 1
 parts:
   wireI: null
 inputX: 1

--- a/stages/wire01.yml
+++ b/stages/wire01.yml
@@ -1,5 +1,5 @@
 name: wire01
-version: 1
+version: 2
 parts:
   wireI: null
 inputX: 1


### PR DESCRIPTION
Fix #187.

要マイグレーション。

* テスト時にデータをインメモリで保持し毎回ロールバックすることにより、APIのテストを簡略化
* `stages.migratedVersion`カラムと`submissions.version`カラムを追加
* ステージのバージョン更新時に走らせるスクリプト、migrateStages.jsを追加
* wire01ステージだけテストのためにバージョンを2にしてある。デプロイ後、migrateStages.jsを走らせる必要がある