### PR TITLE
Board#runを高速化

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,6 +123,10 @@
         "no-bitwise": "off",
         "no-caller": "error",
         "no-catch-shadow": "error",
+        "no-constant-condition": [
+            "error", 
+            { "checkLoops" : false }
+        ],
         "no-confusing-arrow": "off",
         "no-continue": "off",
         "no-div-regex": "error",

--- a/lib/block.js
+++ b/lib/block.js
@@ -13,6 +13,8 @@ class Block extends EventEmitter {
 		this.rotate = config.rotate;
 		this.config = config;
 		this.size = size;
+		this.outputExists = false; // indicates whether self has anything as output now
+		this.passedExists = false; // indicates whether self was passed anything by next-door block, one clock before
 		this.inputQueues = new Map([
 			['top', []],
 			['left', []],
@@ -80,8 +82,8 @@ class Block extends EventEmitter {
 	}
 
 	step() {
-		// returns true if at least one data was output
-		let outputExists = false;
+		this.passedExists = false;
+
 		switch (this.config.type) {
 			case 'empty': {
 				// Erase all data passed to the empty block
@@ -114,7 +116,7 @@ class Block extends EventEmitter {
 						});
 
 						this.emit('pass', {in: input, out: output});
-						outputExists = true;
+						this.outputExists = true;
 					} else {
 						// Erase data when data exists in non-pluged direction
 						while (queue.length) {
@@ -144,7 +146,7 @@ class Block extends EventEmitter {
 						});
 
 						this.emit('pass', {in: input, out: output});
-						outputExists = true;
+						this.outputExists = true;
 					}
 
 					// Erase data when data exists in non-pluged direction
@@ -179,7 +181,7 @@ class Block extends EventEmitter {
 					const output = new Map([[destination, outData]]);
 
 					this.emit('pass', {in: input, out: output});
-					outputExists = true;
+					this.outputExists = true;
 				}
 
 				// Erase data when data exists in non-pluged direction
@@ -222,7 +224,7 @@ class Block extends EventEmitter {
 					const output = new Map([[destination, data]]);
 
 					this.emit('pass', {in: input, out: output});
-					outputExists = true;
+					this.outputExists = true;
 				}
 
 				// Erase data when data exists in non-pluged direction
@@ -258,30 +260,26 @@ class Block extends EventEmitter {
 						const output = new Map([[destination, outData]]);
 
 						this.emit('pass', {in: input, out: output});
-						outputExists = true;
+						this.outputExists = true;
 					}
 				}
 				break;
 			}
 		}
-		return outputExists;
 	}
 
 	pass() {
-		// returns true if at least one data was passed to another block (not board edge)
-		let outputExists = true;
+		this.outputExists = false;
+
 		for (const [direction, queue] of this.outputQueues.entries()) {
 			while (queue.length) {
 				const data = queue.shift();
-				outputExists = this.passTo(direction, data) || outputExists;
+				this.passTo(direction, data);
 			}
 		}
-		return outputExists;
 	}
 
 	passTo(direction, data) {
-		// returns true if data was passed to another block (not board edge)
-		let dataPassed = true;
 		if (
 			direction === 'bottom' &&
 			this.y + 1 === this.board.height &&
@@ -289,50 +287,48 @@ class Block extends EventEmitter {
 		) {
 			this.board.output(data.value);
 			this.emit('erase', data);
-			dataPassed = false;
-			return dataPassed;
+			return;
 		}
 
 		switch (direction) {
 			case 'top':
 				if (0 <= this.y - 1) {
-					this.board.getBlock(this.x, this.y - 1).input('bottom', data);
-					dataPassed = true;
+					const nextBlock = this.board.getBlock(this.x, this.y - 1);
+					nextBlock.input('bottom', data);
+					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
-					dataPassed = false;
 				}
 				break;
 			case 'bottom':
 				if (this.board.height > this.y + 1) {
-					this.board.getBlock(this.x, this.y + 1).input('top', data);
-					dataPassed = true;
+					const nextBlock = this.board.getBlock(this.x, this.y + 1);
+					nextBlock.input('top', data);
+					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
-					dataPassed = false;
 				}
 				break;
 			case 'left':
 				if (0 <= this.x - 1) {
-					this.board.getBlock(this.x - 1, this.y).input('right', data);
-					dataPassed = true;
+					const nextBlock = this.board.getBlock(this.x - 1, this.y);
+					nextBlock.input('right', data);
+					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
-					dataPassed = false;
 				}
 				break;
 			case 'right':
 				if (this.board.width > this.x + 1) {
-					this.board.getBlock(this.x + 1, this.y).input('left', data);
-					dataPassed = true;
+					const nextBlock = this.board.getBlock(this.x + 1, this.y);
+					nextBlock.input('left', data);
+					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
-					dataPassed = false;
 				}
 				break;
 		}
 
-		return dataPassed;
 	}
 
 	clearData() {

--- a/lib/block.js
+++ b/lib/block.js
@@ -278,8 +278,8 @@ class Block extends EventEmitter {
 	passTo(direction, data) {
 		if (
 			direction === 'bottom' &&
-				this.y + 1 === this.board.height &&
-				this.x === this.board.outputBlockX
+			this.y + 1 === this.board.height &&
+			this.x === this.board.outputBlockX
 		) {
 			this.board.output(data.value);
 			this.emit('erase', data);

--- a/lib/block.js
+++ b/lib/block.js
@@ -81,7 +81,7 @@ class Block extends EventEmitter {
 
 	step() {
 		let noOutput = true;
-		switch(this.config.type) {
+		switch (this.config.type) {
 			case 'empty': {
 				// Erase all data passed to the empty block
 				for (const queue of this.inputQueues.values()) {

--- a/lib/block.js
+++ b/lib/block.js
@@ -328,7 +328,6 @@ class Block extends EventEmitter {
 				}
 				break;
 		}
-
 	}
 
 	clearData() {

--- a/lib/block.js
+++ b/lib/block.js
@@ -267,15 +267,20 @@ class Block extends EventEmitter {
 	}
 
 	pass() {
+		// returns if at least one data was passed to another block (not board edge)
+		let outputExists = true;
 		for (const [direction, queue] of this.outputQueues.entries()) {
 			while (queue.length) {
 				const data = queue.shift();
-				this.passTo(direction, data);
+				outputExists = this.passTo(direction, data) || outputExists;
 			}
 		}
+		return outputExists;
 	}
 
 	passTo(direction, data) {
+		// returns if data was passed to another block (not board edge)
+		let dataPassed = true;
 		if (
 			direction === 'bottom' &&
 			this.y + 1 === this.board.height &&
@@ -283,39 +288,50 @@ class Block extends EventEmitter {
 		) {
 			this.board.output(data.value);
 			this.emit('erase', data);
-			return;
+			dataPassed = false;
+			return dataPassed;
 		}
 
 		switch (direction) {
 			case 'top':
 				if (0 <= this.y - 1) {
 					this.board.getBlock(this.x, this.y - 1).input('bottom', data);
+					dataPassed = true;
 				} else {
 					this.emit('erase', data);
+					dataPassed = false;
 				}
 				break;
 			case 'bottom':
 				if (this.board.height > this.y + 1) {
 					this.board.getBlock(this.x, this.y + 1).input('top', data);
+					dataPassed = true;
 				} else {
 					this.emit('erase', data);
+					dataPassed = false;
 				}
 				break;
 			case 'left':
 				if (0 <= this.x - 1) {
 					this.board.getBlock(this.x - 1, this.y).input('right', data);
+					dataPassed = true;
 				} else {
 					this.emit('erase', data);
+					dataPassed = false;
 				}
 				break;
 			case 'right':
 				if (this.board.width > this.x + 1) {
 					this.board.getBlock(this.x + 1, this.y).input('left', data);
+					dataPassed = true;
 				} else {
 					this.emit('erase', data);
+					dataPassed = false;
 				}
 				break;
 		}
+
+		return dataPassed;
 	}
 
 	clearData() {

--- a/lib/block.js
+++ b/lib/block.js
@@ -80,7 +80,7 @@ class Block extends EventEmitter {
 	}
 
 	step() {
-		// returns if at least one data was output
+		// returns true if at least one data was output
 		let outputExists = false;
 		switch (this.config.type) {
 			case 'empty': {
@@ -268,7 +268,7 @@ class Block extends EventEmitter {
 	}
 
 	pass() {
-		// returns if at least one data was passed to another block (not board edge)
+		// returns true if at least one data was passed to another block (not board edge)
 		let outputExists = true;
 		for (const [direction, queue] of this.outputQueues.entries()) {
 			while (queue.length) {
@@ -280,7 +280,7 @@ class Block extends EventEmitter {
 	}
 
 	passTo(direction, data) {
-		// returns if data was passed to another block (not board edge)
+		// returns true if data was passed to another block (not board edge)
 		let dataPassed = true;
 		if (
 			direction === 'bottom' &&

--- a/lib/block.js
+++ b/lib/block.js
@@ -80,7 +80,8 @@ class Block extends EventEmitter {
 	}
 
 	step() {
-		let noOutput = true;
+		// returns if at least one data was output
+		let outputExists = false;
 		switch (this.config.type) {
 			case 'empty': {
 				// Erase all data passed to the empty block
@@ -113,7 +114,7 @@ class Block extends EventEmitter {
 						});
 
 						this.emit('pass', {in: input, out: output});
-						noOutput = false;
+						outputExists = true;
 					} else {
 						// Erase data when data exists in non-pluged direction
 						while (queue.length) {
@@ -143,7 +144,7 @@ class Block extends EventEmitter {
 						});
 
 						this.emit('pass', {in: input, out: output});
-						noOutput = false;
+						outputExists = true;
 					}
 
 					// Erase data when data exists in non-pluged direction
@@ -178,7 +179,7 @@ class Block extends EventEmitter {
 					const output = new Map([[destination, outData]]);
 
 					this.emit('pass', {in: input, out: output});
-					noOutput = false;
+					outputExists = true;
 				}
 
 				// Erase data when data exists in non-pluged direction
@@ -221,7 +222,7 @@ class Block extends EventEmitter {
 					const output = new Map([[destination, data]]);
 
 					this.emit('pass', {in: input, out: output});
-					noOutput = false;
+					outputExists = true;
 				}
 
 				// Erase data when data exists in non-pluged direction
@@ -257,13 +258,13 @@ class Block extends EventEmitter {
 						const output = new Map([[destination, outData]]);
 
 						this.emit('pass', {in: input, out: output});
-						noOutput = false;
+						outputExists = true;
 					}
 				}
 				break;
 			}
 		}
-		return noOutput;
+		return outputExists;
 	}
 
 	pass() {

--- a/lib/block.js
+++ b/lib/block.js
@@ -13,8 +13,8 @@ class Block extends EventEmitter {
 		this.rotate = config.rotate;
 		this.config = config;
 		this.size = size;
+		this.inputExists = false; // indicates whether self has input
 		this.outputExists = false; // indicates whether self has anything as output now
-		this.passedExists = false; // indicates whether self was passed anything by next-door block, one clock before
 		this.inputQueues = new Map([
 			['top', []],
 			['left', []],
@@ -78,11 +78,12 @@ class Block extends EventEmitter {
 	}
 
 	input(position, data) {
+		this.inputExists = true;
 		this.inputQueues.get(position).push(data);
 	}
 
 	step() {
-		this.passedExists = false;
+		this.inputExists = false;
 
 		switch (this.config.type) {
 			case 'empty': {
@@ -295,7 +296,6 @@ class Block extends EventEmitter {
 				if (0 <= this.y - 1) {
 					const nextBlock = this.board.getBlock(this.x, this.y - 1);
 					nextBlock.input('bottom', data);
-					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
 				}
@@ -304,7 +304,6 @@ class Block extends EventEmitter {
 				if (this.board.height > this.y + 1) {
 					const nextBlock = this.board.getBlock(this.x, this.y + 1);
 					nextBlock.input('top', data);
-					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
 				}
@@ -313,7 +312,6 @@ class Block extends EventEmitter {
 				if (0 <= this.x - 1) {
 					const nextBlock = this.board.getBlock(this.x - 1, this.y);
 					nextBlock.input('right', data);
-					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
 				}
@@ -322,7 +320,6 @@ class Block extends EventEmitter {
 				if (this.board.width > this.x + 1) {
 					const nextBlock = this.board.getBlock(this.x + 1, this.y);
 					nextBlock.input('left', data);
-					nextBlock.passedExists = true;
 				} else {
 					this.emit('erase', data);
 				}

--- a/lib/block.js
+++ b/lib/block.js
@@ -26,6 +26,9 @@ class Block extends EventEmitter {
 			['right', []],
 			['bottom', []],
 		]);
+		if (this.config.type === 'wire' || this.config.type === 'calc') {
+			this.rotatedPlugs = this.config.io.plugs.map((direction) => (this.rotatedDirection(direction)));
+		}
 	}
 
 	get center() {
@@ -77,177 +80,190 @@ class Block extends EventEmitter {
 	}
 
 	step() {
-		if (this.config.type === 'empty') {
-			// Erase all data passed to the empty block
-			for (const queue of this.inputQueues.values()) {
-				while (queue.length) {
-					const data = queue.shift();
-					this.emit('erase', data);
-				}
-			}
-		} else if (this.config.type === 'wire') {
-			const rotatedPlugs = this.config.io.plugs.map((direction) => (
-				this.rotatedDirection(direction)
-			));
-
-			for (const [source, queue] of this.inputQueues.entries()) {
-				// When data exists in pluged direction
-				if (queue.length !== 0 && rotatedPlugs.includes(source)) {
-					const destinations = rotatedPlugs.filter((direction) => direction !== source);
-					const data = queue.shift();
-
-					// pass through
-					const input = new Map([[source, data]]);
-
-					const output = new Map();
-					destinations.forEach((direction) => {
-						const outData = new Data(this.board, data.value);
-						this.outputQueues.get(direction).push(outData);
-						output.set(direction, outData);
-					});
-
-					this.emit('pass', {in: input, out: output});
-				}
-
-				// Erase data when data exists in non-pluged direction
-				if (!rotatedPlugs.includes(source)) {
+		let noOutput = true;
+		switch(this.config.type) {
+			case 'empty': {
+				// Erase all data passed to the empty block
+				for (const queue of this.inputQueues.values()) {
 					while (queue.length) {
 						const data = queue.shift();
 						this.emit('erase', data);
 					}
 				}
+				break;
 			}
-		} else if (this.config.type === 'calc') {
-			const rotatedPlugs = this.config.io.plugs.map((direction) => (
-				this.rotatedDirection(direction)
-			));
+			case 'wire': {
+				for (const [source, queue] of this.inputQueues.entries()) {
+					// When data exists in pluged direction
+					if (queue.length === 0) {
+						continue;
+					}
+					if (this.rotatedPlugs.includes(source)) {
+						const destinations = this.rotatedPlugs.filter((direction) => direction !== source);
+						const data = queue.shift();
 
-			for (const [source, queue] of this.inputQueues.entries()) {
-				// When data exists in pluged direction
-				if (queue.length !== 0 && rotatedPlugs.includes(source)) {
-					const destinations = rotatedPlugs.filter((direction) => direction !== source);
-					const data = queue.shift();
+						// pass through
+						const input = new Map([[source, data]]);
+
+						const output = new Map();
+						destinations.forEach((direction) => {
+							const outData = new Data(this.board, data.value);
+							this.outputQueues.get(direction).push(outData);
+							output.set(direction, outData);
+						});
+
+						this.emit('pass', {in: input, out: output});
+						noOutput = false;
+					} else {
+						// Erase data when data exists in non-pluged direction
+						while (queue.length) {
+							const data = queue.shift();
+							this.emit('erase', data);
+						}
+					}
+				}
+				break;
+			}
+			case 'calc': {
+				for (const [source, queue] of this.inputQueues.entries()) {
+					// When data exists in pluged direction
+					if (queue.length !== 0 && this.rotatedPlugs.includes(source)) {
+						const destinations = this.rotatedPlugs.filter((direction) => direction !== source);
+						const data = queue.shift();
+
+						// Calculate and pass through
+						const input = new Map([[source, data]]);
+
+						const output = new Map();
+						destinations.forEach((direction) => {
+							const value = this.config.func(data.value);
+							const outData = new Data(this.board, isNaN(value) ? 0 : value);
+							this.outputQueues.get(direction).push(outData);
+							output.set(direction, outData);
+						});
+
+						this.emit('pass', {in: input, out: output});
+						noOutput = false;
+					}
+
+					// Erase data when data exists in non-pluged direction
+					if (!this.rotatedPlugs.includes(source)) {
+						while (queue.length) {
+							const data = queue.shift();
+							this.emit('erase', data);
+						}
+					}
+				}
+				break;
+			}
+			case 'calc2': {
+				const sources = this.config.io.in.map((direction) => this.rotatedDirection(direction));
+				const destination = this.rotatedDirection(this.config.io.out);
+
+				// Execute calculation when all inputs are satisfied
+				if (sources.every((source) => this.inputQueues.get(source).length > 0)) {
+					const datas = [];
 
 					// Calculate and pass through
-					const input = new Map([[source, data]]);
-
-					const output = new Map();
-					destinations.forEach((direction) => {
-						const value = this.config.func(data.value);
-						const outData = new Data(this.board, isNaN(value) ? 0 : value);
-						this.outputQueues.get(direction).push(outData);
-						output.set(direction, outData);
+					const input = new Map();
+					sources.forEach((source) => {
+						const data = this.inputQueues.get(source).shift();
+						input.set(source, data);
+						datas.push(data);
 					});
 
-					this.emit('pass', {in: input, out: output});
-				}
-
-				// Erase data when data exists in non-pluged direction
-				if (!rotatedPlugs.includes(source)) {
-					while (queue.length) {
-						const data = queue.shift();
-						this.emit('erase', data);
-					}
-				}
-			}
-		} else if (this.config.type === 'calc2') {
-			const sources = this.config.io.in.map((direction) => this.rotatedDirection(direction));
-			const destination = this.rotatedDirection(this.config.io.out);
-
-			// Execute calculation when all inputs are satisfied
-			if (sources.every((source) => this.inputQueues.get(source).length > 0)) {
-				const datas = [];
-
-				// Calculate and pass through
-				const input = new Map();
-				sources.forEach((source) => {
-					const data = this.inputQueues.get(source).shift();
-					input.set(source, data);
-					datas.push(data);
-				});
-
-				const value = this.config.func(...datas.map((data) => data.value));
-				const outData = new Data(this.board, isNaN(value) ? 0 : value);
-				this.outputQueues.get(destination).push(outData);
-				const output = new Map([[destination, outData]]);
-
-				this.emit('pass', {in: input, out: output});
-			}
-
-			// Erase data when data exists in non-pluged direction
-			for (const [source, queue] of this.inputQueues.entries()) {
-				if (!sources.includes(source)) {
-					while (queue.length) {
-						const data = queue.shift();
-						this.emit('erase', data);
-					}
-				}
-			}
-		} else if (this.config.type === 'calc-switch') {
-			const sources = this.config.io.in.map((direction) => (
-				this.rotatedDirection(direction)
-			));
-			const destinations = this.config.io.out.map((direction) => (
-				this.rotatedDirection(direction)
-			));
-
-			// Execute calculation when all inputs are satisfied
-			if (sources.every((source) => this.inputQueues.get(source).length > 0)) {
-				const datas = [];
-
-				// Calculate and pass through
-				const input = new Map();
-				sources.forEach((source) => {
-					const data = this.inputQueues.get(source).shift();
-					input.set(source, data);
-					datas.push(data);
-				});
-
-				const values = datas.map((data) => data.value);
-				const {directionIndex, value} = this.config.func(...values);
-
-				const data = new Data(this.board, isNaN(value) ? 0 : value);
-				const destination = destinations[directionIndex];
-				this.outputQueues.get(destination).push(data);
-				const output = new Map([[destination, data]]);
-
-				this.emit('pass', {in: input, out: output});
-			}
-
-			// Erase data when data exists in non-pluged direction
-			for (const [source, queue] of this.inputQueues.entries()) {
-				if (!sources.includes(source)) {
-					while (queue.length) {
-						const data = queue.shift();
-						this.emit('erase', data);
-					}
-				}
-			}
-		} else if (this.config.type === 'wireX') {
-			const oppositeDirection = {
-				top: 'bottom',
-				bottom: 'top',
-				left: 'right',
-				right: 'left',
-			};
-			for (const [source, queue] of this.inputQueues.entries()) {
-				const destination = oppositeDirection[source];
-
-				// When data exists in pluged direction
-				if (queue.length !== 0) {
-					const data = queue.shift();
-
-					// pass through
-					const input = new Map([[source, data]]);
-
-					const outData = new Data(this.board, data.value);
+					const value = this.config.func(...datas.map((data) => data.value));
+					const outData = new Data(this.board, isNaN(value) ? 0 : value);
 					this.outputQueues.get(destination).push(outData);
 					const output = new Map([[destination, outData]]);
 
 					this.emit('pass', {in: input, out: output});
+					noOutput = false;
 				}
+
+				// Erase data when data exists in non-pluged direction
+				for (const [source, queue] of this.inputQueues.entries()) {
+					if (!sources.includes(source)) {
+						while (queue.length) {
+							const data = queue.shift();
+							this.emit('erase', data);
+						}
+					}
+				}
+				break;
+			}
+			case 'calc-switch': {
+				const sources = this.config.io.in.map((direction) => (
+					this.rotatedDirection(direction)
+				));
+				const destinations = this.config.io.out.map((direction) => (
+					this.rotatedDirection(direction)
+				));
+
+				// Execute calculation when all inputs are satisfied
+				if (sources.every((source) => this.inputQueues.get(source).length > 0)) {
+					const datas = [];
+
+					// Calculate and pass through
+					const input = new Map();
+					sources.forEach((source) => {
+						const data = this.inputQueues.get(source).shift();
+						input.set(source, data);
+						datas.push(data);
+					});
+
+					const values = datas.map((data) => data.value);
+					const {directionIndex, value} = this.config.func(...values);
+
+					const data = new Data(this.board, isNaN(value) ? 0 : value);
+					const destination = destinations[directionIndex];
+					this.outputQueues.get(destination).push(data);
+					const output = new Map([[destination, data]]);
+
+					this.emit('pass', {in: input, out: output});
+					noOutput = false;
+				}
+
+				// Erase data when data exists in non-pluged direction
+				for (const [source, queue] of this.inputQueues.entries()) {
+					if (!sources.includes(source)) {
+						while (queue.length) {
+							const data = queue.shift();
+							this.emit('erase', data);
+						}
+					}
+				}
+				break;
+			}
+			case 'wireX': {
+				const oppositeDirection = {
+					top: 'bottom',
+					bottom: 'top',
+					left: 'right',
+					right: 'left',
+				};
+				for (const [source, queue] of this.inputQueues.entries()) {
+					const destination = oppositeDirection[source];
+
+					// When data exists in pluged direction
+					if (queue.length !== 0) {
+						const data = queue.shift();
+
+						// pass through
+						const input = new Map([[source, data]]);
+
+						const outData = new Data(this.board, data.value);
+						this.outputQueues.get(destination).push(outData);
+						const output = new Map([[destination, outData]]);
+
+						this.emit('pass', {in: input, out: output});
+						noOutput = false;
+					}
+				}
+				break;
 			}
 		}
+		return noOutput;
 	}
 
 	pass() {
@@ -262,8 +278,8 @@ class Block extends EventEmitter {
 	passTo(direction, data) {
 		if (
 			direction === 'bottom' &&
-			this.y + 1 === this.board.height &&
-			this.x === this.board.outputBlockX
+				this.y + 1 === this.board.height &&
+				this.x === this.board.outputBlockX
 		) {
 			this.board.output(data.value);
 			this.emit('erase', data);

--- a/lib/board.js
+++ b/lib/board.js
@@ -254,13 +254,13 @@ class Board extends EventEmitter {
 	}
 
 	step() {
-		let noOutput = true;
+		let outputExists = false;
 		this.forBlocks((block) => {
-			noOutput = block.step() && noOutput;
+			outputExists = block.step() || outputExists;
 		});
 		this.clock++;
 
-		if (noOutput) {
+		if (!outputExists) {
 			if (this.dataExists) {
 				this.pause();
 			} else {

--- a/lib/board.js
+++ b/lib/board.js
@@ -260,17 +260,22 @@ class Board extends EventEmitter {
 		});
 		this.clock++;
 
-		if (!this.dataExists) {
-			this.halt();
-		} else if (noOutput) {
-			this.pause();
+		if (noOutput) {
+			if (this.dataExists) {
+				this.pause();
+			} else {
+				this.halt();
+			}
 		}
 	}
 
 	pass() {
-		this.forBlocks((block) => block.pass());
+		let outputExists = false;
+		this.forBlocks((block) => {
+			outputExists = block.pass() || outputExists;
+		});
 
-		if (!this.dataExists) {
+		if (!outputExists) {
 			this.halt();
 		}
 	}

--- a/lib/board.js
+++ b/lib/board.js
@@ -194,7 +194,7 @@ class Board extends EventEmitter {
 		this.input(inputValue);
 
 		const clockUp = () => {
-			for (;;) {
+			while (true) {
 				this.step();
 
 				if (this.status === 'stop' || this.status === 'paused') {

--- a/lib/board.js
+++ b/lib/board.js
@@ -254,11 +254,13 @@ class Board extends EventEmitter {
 	}
 
 	step() {
+		this.forBlocks((block) => block.step());
+		this.clock++;
+
 		let outputExists = false;
 		this.forBlocks((block) => {
-			outputExists = block.step() || outputExists;
+			outputExists = block.outputExists || outputExists;
 		});
-		this.clock++;
 
 		if (!outputExists) {
 			if (this.dataExists) {
@@ -270,12 +272,14 @@ class Board extends EventEmitter {
 	}
 
 	pass() {
-		let outputExists = false;
+		this.forBlocks((block) => block.pass());
+
+		let passedExists = false;
 		this.forBlocks((block) => {
-			outputExists = block.pass() || outputExists;
+			passedExists = block.passedExists || passedExists;
 		});
 
-		if (!outputExists) {
+		if (!passedExists) {
 			this.halt();
 		}
 	}

--- a/lib/board.js
+++ b/lib/board.js
@@ -90,19 +90,6 @@ class Board extends EventEmitter {
 		return count;
 	}
 
-	get datas() {
-		return this.blocks.reduce((previousRow, row) => (
-			previousRow.concat(row.reduce((previousBlock, block) => {
-				let datas = [];
-				for (const direction of block.inputQueues.keys()) {
-					datas = datas.concat(block.inputQueues.get(direction));
-					datas = datas.concat(block.outputQueues.get(direction));
-				}
-				return previousBlock.concat(datas);
-			}, []))
-		), []);
-	}
-
 	// Generate the JSON serializable board data that can be exchanged between API
 	get boardData() {
 		const blocks = [];
@@ -185,27 +172,28 @@ class Board extends EventEmitter {
 
 		// 頼む～ES6末尾再帰最適化実装してくれ～という気分
 		const clockUp = () => {
-			this.step();
+			while(true) {
+				this.step();
 
-			if (this.status === 'stop' || this.status === 'paused') {
-				return null;
+				if (this.status === 'stop' || this.status === 'paused') {
+					return null;
+				}
+
+				this.pass();
+
+				if (this.status === 'stop' || this.status === 'paused') {
+					return null;
+				}
+
+				if (this.clock >= this.clockLimit) {
+					return null;
+				}
+
+				if (this.dataCount >= 100) {
+					return null;
+				}
+
 			}
-
-			this.pass();
-
-			if (this.status === 'stop' || this.status === 'paused') {
-				return null;
-			}
-
-			if (this.clock >= this.clockLimit) {
-				return null;
-			}
-
-			if (this.dataCount > 100) {
-				return null;
-			}
-
-			return clockUp();
 		};
 
 		clockUp();
@@ -245,31 +233,23 @@ class Board extends EventEmitter {
 	}
 
 	step() {
-		this.forBlocks((block) => block.step());
+		let noOutput = true;
+		this.forBlocks((block) => {
+			noOutput = block.step() && noOutput;
+		});
 		this.clock++;
 
-		if (this.datas.length === 0) {
+		if (this.dataCount === 0) {
 			this.halt();
-		} else {
-			let noOutput = true;
-			this.forBlocks((block) => {
-				for (const queue of block.outputQueues.values()) {
-					if (queue.length > 0) {
-						noOutput = false;
-						break;
-					}
-				}
-			});
-			if (noOutput) {
-				this.pause();
-			}
+		} else if (noOutput) {
+			this.pause();
 		}
 	}
 
 	pass() {
 		this.forBlocks((block) => block.pass());
 
-		if (this.datas.length === 0) {
+		if (this.dataCount === 0) {
 			this.halt();
 		}
 	}

--- a/lib/board.js
+++ b/lib/board.js
@@ -90,6 +90,29 @@ class Board extends EventEmitter {
 		return count;
 	}
 
+	get dataExists() {
+		let res = false;
+		this.forBlocks((block) => {
+			if (res === true) {
+				return;
+			}
+			for (const queue of block.inputQueues.values()) {
+				if (queue.length > 0) {
+					res = true;
+					return;
+				}
+			}
+			for (const queue of block.outputQueues.values()) {
+				if (queue.length > 0) {
+					res = true;
+					return;
+				}
+			}
+		});
+
+		return res;
+	}
+
 	// Generate the JSON serializable board data that can be exchanged between API
 	get boardData() {
 		const blocks = [];
@@ -170,7 +193,6 @@ class Board extends EventEmitter {
 	run(inputValue) {
 		this.input(inputValue);
 
-		// 頼む～ES6末尾再帰最適化実装してくれ～という気分
 		const clockUp = () => {
 			while(true) {
 				this.step();
@@ -239,7 +261,7 @@ class Board extends EventEmitter {
 		});
 		this.clock++;
 
-		if (this.dataCount === 0) {
+		if (!this.dataExists) {
 			this.halt();
 		} else if (noOutput) {
 			this.pause();
@@ -249,7 +271,7 @@ class Board extends EventEmitter {
 	pass() {
 		this.forBlocks((block) => block.pass());
 
-		if (this.dataCount === 0) {
+		if (!this.dataExists) {
 			this.halt();
 		}
 	}

--- a/lib/board.js
+++ b/lib/board.js
@@ -194,7 +194,7 @@ class Board extends EventEmitter {
 		this.input(inputValue);
 
 		const clockUp = () => {
-			while(true) {
+			for (;;) {
 				this.step();
 
 				if (this.status === 'stop' || this.status === 'paused') {
@@ -214,7 +214,6 @@ class Board extends EventEmitter {
 				if (this.dataCount >= 100) {
 					return null;
 				}
-
 			}
 		};
 

--- a/lib/board.js
+++ b/lib/board.js
@@ -274,12 +274,12 @@ class Board extends EventEmitter {
 	pass() {
 		this.forBlocks((block) => block.pass());
 
-		let passedExists = false;
+		let inputExists = false;
 		this.forBlocks((block) => {
-			passedExists = block.passedExists || passedExists;
+			inputExists = block.inputExists || inputExists;
 		});
 
-		if (!passedExists) {
+		if (!inputExists) {
 			this.halt();
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "unit": "npm run mochify:node && npm run mochify:phantom",
     "functional": "mocha \"test/functional/index.ls\" --reporter spec --compilers ls:livescript",
     "coveralls": "lcov-result-merger \"{coverage/lcov.info,api/coverage/lcov.info}\" | coveralls",
-    "lint": "eslint --rule 'no-constant-condition: [\"error\", { \"checkLoops\" : false }]' \"lib/**/*.js\" \"api/**/*.js\" --ignore-pattern \"lib/analytics.js\" --ignore-pattern \"api/coverage/**/*.js\"",
+    "lint": "eslint \"lib/**/*.js\" \"api/**/*.js\" --ignore-pattern \"lib/analytics.js\" --ignore-pattern \"api/coverage/**/*.js\"",
     "test": "npm run unit && npm run functional && npm run lint",
     "api:init": "cd api && sequelize db:migrate:undo:all && sequelize db:migrate && sequelize db:seed:all",
     "api": "cd api && node index.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "unit": "npm run mochify:node && npm run mochify:phantom",
     "functional": "mocha \"test/functional/index.ls\" --reporter spec --compilers ls:livescript",
     "coveralls": "lcov-result-merger \"{coverage/lcov.info,api/coverage/lcov.info}\" | coveralls",
-    "lint": "eslint \"lib/**/*.js\" \"api/**/*.js\" --ignore-pattern \"lib/analytics.js\" --ignore-pattern \"api/coverage/**/*.js\"",
+    "lint": "eslint --rule 'no-constant-condition: [\"error\", { \"checkLoops\" : false }]' \"lib/**/*.js\" \"api/**/*.js\" --ignore-pattern \"lib/analytics.js\" --ignore-pattern \"api/coverage/**/*.js\"",
     "test": "npm run unit && npm run functional && npm run lint",
     "api:init": "cd api && sequelize db:migrate:undo:all && sequelize db:migrate && sequelize db:seed:all",
     "api": "cd api && node index.js",

--- a/test/unit/board.ls
+++ b/test/unit/board.ls
@@ -57,7 +57,7 @@ describe 'Board' ->
       expect @board.data-count .to.equal 3
 
   describe '#dataExists' ->
-    It 'returns if any data exist on the current board' ->
+    It 'returns true if any data exist on the current board' ->
       @board.place-block x: 2, y: 0, type: \wireXdot, rotate: 0
       @board.input 100
       expect @board.data-exists .to.be.true

--- a/test/unit/board.ls
+++ b/test/unit/board.ls
@@ -56,6 +56,18 @@ describe 'Board' ->
 
       expect @board.data-count .to.equal 3
 
+  describe '#dataExists' ->
+    It 'returns if any data exist on the current board' ->
+      @board.place-block x: 2, y: 0, type: \wireXdot, rotate: 0
+      @board.input 100
+      expect @board.data-exists .to.be.true
+      @board.step!
+      expect @board.data-exists .to.be.true
+      @board.pass!
+      expect @board.data-exists .to.be.true
+      @board.step!
+      expect @board.data-exists .to.be.false
+
   describe '#blockCount' ->
     It 'counts blocks in board' ->
       @board.place-block x: 2, y: 1, type: \wireI, rotate: 0


### PR DESCRIPTION
#150 について。1.6倍の速さになった。

検証では、1000クロック回した。
``` diff
diff --git a/test/unit/board.ls b/test/unit/board.ls
index 6ec954a..be28880 100644
--- a/test/unit/board.ls
+++ b/test/unit/board.ls
@@ -14,7 +14,7 @@ describe 'Board' ->
       outputX: 2
       width: 5
       height: 4
-      clock-limit: 100
+      clock-limit: 1000

   It 'carries input data to output when plugged input and output by wires' ->
     resolve, reject <~ new Promise _
@@ -121,6 +121,8 @@ describe 'Board' ->
       expect @board.clock .to.equal 3

     It 'limits maximum execution clocks to stage\'s clock limit' ->
+      @timeout 10000
+
       @board.place-block x: 1, y: 0, type: \wireL, rotate: 1
       @board.place-block x: 2, y: 0, type: \wireT, rotate: 3
       @board.place-block x: 1, y: 1, type: \wireL, rotate: 0
@@ -129,7 +131,7 @@ describe 'Board' ->
       @board.run 7

       expect @board.output-value .to.be.null
-      expect @board.clock .to.equal 100
+      expect @board.clock .to.equal 1000

     It 'limits simultaneous data count to 100' ->
       for x from 0 to 4
```
として、このテストを使って時間を計測した。

直す前に動かしながらボトルネックを探すとかはあんまりやってない。
実施した変更は3点。
- Board#stepで、新たな出力があったかどうか調べていたのをBlock#stepにやらせる(4381ms->3913ms)
- Board#step, passでget datasを使っていたのを、dataCountを使うようにする(->3334ms)
- さらにdataCountでなくてdataExistsを定義して、使う。(->2733ms)

Block#step、どうせ何も返していなかったので、自分が何か出力したかどうかを変えさせて、Board#stepで調査していた分を省略した。

get datas、配列をconcatしまくってて、重そうな上に、datasの使われ方がそのあとlengthをとるだけだったので、dataExistsとかいうdataがあったらtrueを返すだけのものを作った。

get datas、使われなくなったので消した。

1.6倍って微妙だよなぁ。