### PR TITLE
Panel#takeAndPlaceをStageに移動

### DIFF
--- a/lib/panel.js
+++ b/lib/panel.js
@@ -1,107 +1,53 @@
 const $ = require('jquery');
-const assert = require('assert');
 
 class Panel {
-	constructor(stage) {
-		this.stage = stage;
+	constructor(partsLimit, $panel) {
 		this.parts = new Map();
-		Object.keys(stage.config.parts).forEach((name, index) => {
-			const count = stage.config.parts[name];
+		Object.keys(partsLimit).forEach((name, index) => {
+			const count = partsLimit[name];
 			this.parts.set(name, count);
 			if (index === 0) {
 				this.selected = name;
 			}
 		});
-		this.$panel = this.stage.$stage.find('.panel');
+		this.$panel = $panel;
 		this.update();
 	}
 
 	/**
 	 *  panel上にblockを追加する
-	 *  @param {string} itemName - 追加するblock名
-	 *  @param {number} count - 追加する量
-	 *  @return {bool} 処理が成功したかどうか
+	 *  @param {string} blockName - 追加するblock名
+	 *  @return {null} null - null
 	 */
-	addItem(itemName, count) {
-		if (!this.parts.has(itemName)) {
-			this.parts.set(itemName, count);
-			return true;
+	push(blockName) {
+		let currentCount = 0;
+		if (this.parts.has(blockName)) {
+			currentCount = this.parts.get(blockName);
 		}
-		const currentCount = this.parts.get(itemName);
-		if (currentCount === null) {	// null means infinity
-			return true;
+		if (currentCount !== null) {	// null means infinity
+			this.parts.set(blockName, currentCount + 1);
 		}
-		this.parts.set(itemName, currentCount + count);
 		return true;
 	}
 
 	/**
 	 *  panel上のblockを減らす
-	 *  @param {string} itemName - 消費するblock名
-	 *  @param {number} count - 消費する量
-	 *  @return {bool} 処理が成功したかどうか
+	 *  @param {string} blockName - 消費するblock名
+	 *  @return {bool} 正しくblockを減らせたかどうか
 	 */
-	removeItem(itemName, count) {
-		if (!this.parts.has(itemName)) {
+	take(blockName) {
+		if (!this.parts.has(blockName)) {
 			return false;
 		}
-		const currentCount = this.parts.get(itemName);
-		if (currentCount === null) {	// null means infinity
-			return true;
-		}
-		if (currentCount - count > 0) {
-			this.parts.set(itemName, currentCount - count);
-			return true;
-		}
-		if (currentCount - count < 0) {	// if panel doesn't have enough item
-			return false;
-		}
-		this.parts.delete(itemName);
-		return true;
-	}
-
-	takeAndPlace(x, y, blockName) {
-		const oldBlock = this.stage.board.getBlock(x, y);
-		assert(oldBlock, 'oldBlock is invalid');
-		if (blockName === 'empty') {	// just take the block
-			if (oldBlock.config.name !== 'empty') {
-				// take the block from the board
-				this.addItem(oldBlock.config.name, 1);
-				this.stage.boardElement.placeBlock({x, y, type: blockName, rotate: 0});
-				this.update();
-			}
-			return;
-		}
-
-		if (this.parts.has(blockName)) {
-			let rotate = 0;
-
-			if (oldBlock.config.name === 'empty') {
-				// just place the block
-				this.removeItem(blockName, 1);
-			} else if (oldBlock.config.name === blockName && oldBlock.config.rotatable) {
-				rotate = (oldBlock.rotate + 1) % 4;
+		const currentCount = this.parts.get(blockName);
+		if (currentCount !== null) {	// null means infinity
+			if (currentCount - 1 === 0) { // take the last block
+				this.parts.delete(blockName);
 			} else {
-				// take and place
-				this.removeItem(blockName, 1);
-				this.addItem(oldBlock.config.name, 1);
+				this.parts.set(blockName, currentCount - 1);
 			}
-
-			if (!this.parts.has(blockName)) {
-				this.selected = null;
-			}
-
-			this.stage.boardElement.placeBlock({x, y, type: blockName, rotate});
-			this.update();
-		} else if (
-			!this.selected &&
-			oldBlock.config.name !== 'empty' &&
-			oldBlock.config.rotatable
-		) {
-			const rotate = (oldBlock.rotate + 1) % 4;
-			this.stage.boardElement.placeBlock({x, y, type: oldBlock.config.name, rotate});
-			this.update();
 		}
+		return true;
 	}
 
 	update() {
@@ -119,8 +65,6 @@ class Panel {
 			})));
 		});
 
-		this.selected = this.$panel.find('.block[selected]').first().data('type');
-
 		this.$panel.find('.block').click((event) => {
 			const $block = $(event.target);
 
@@ -128,7 +72,6 @@ class Panel {
 			$block.attr('selected', true);
 
 			this.selected = $block.data('type');
-			this.stage.$selectedBlock = $block;
 		});
 	}
 }

--- a/lib/panel.js
+++ b/lib/panel.js
@@ -27,27 +27,25 @@ class Panel {
 		if (currentCount !== null) {	// null means infinity
 			this.parts.set(blockName, currentCount + 1);
 		}
-		return true;
+		this.update();
 	}
 
 	/**
 	 *  panel上のblockを減らす
 	 *  @param {string} blockName - 消費するblock名
-	 *  @return {bool} 正しくblockを減らせたかどうか
+	 *  @return {undefined}
 	 */
 	take(blockName) {
-		if (!this.parts.has(blockName)) {
-			return false;
-		}
 		const currentCount = this.parts.get(blockName);
 		if (currentCount !== null) {	// null means infinity
 			if (currentCount - 1 === 0) { // take the last block
+				this.selected = undefined;
 				this.parts.delete(blockName);
 			} else {
 				this.parts.set(blockName, currentCount - 1);
 			}
 		}
-		return true;
+		this.update();
 	}
 
 	update() {

--- a/lib/panel.js
+++ b/lib/panel.js
@@ -1,4 +1,5 @@
 const $ = require('jquery');
+const assert = require('assert');
 
 class Panel {
 	constructor(partsLimit, $panel) {
@@ -36,8 +37,12 @@ class Panel {
 	 *  @return {undefined}
 	 */
 	take(blockName) {
+		assert(this.parts.has(blockName), 'try to take non-existent block');
+
 		const currentCount = this.parts.get(blockName);
 		if (currentCount !== null) {	// null means infinity
+			assert(currentCount > 0, 'the block isn\'t remaining');
+
 			if (currentCount - 1 === 0) { // take the last block
 				this.selected = null;
 				this.parts.delete(blockName);

--- a/lib/panel.js
+++ b/lib/panel.js
@@ -39,7 +39,7 @@ class Panel {
 		const currentCount = this.parts.get(blockName);
 		if (currentCount !== null) {	// null means infinity
 			if (currentCount - 1 === 0) { // take the last block
-				this.selected = undefined;
+				this.selected = null;
 				this.parts.delete(blockName);
 			} else {
 				this.parts.set(blockName, currentCount - 1);

--- a/lib/panel.js
+++ b/lib/panel.js
@@ -17,7 +17,7 @@ class Panel {
 	/**
 	 *  panel上にblockを追加する
 	 *  @param {string} blockName - 追加するblock名
-	 *  @return {null} null - null
+	 *  @return {undefined}
 	 */
 	push(blockName) {
 		let currentCount = 0;

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -403,7 +403,7 @@ class Stage {
 		if (!blockName || blockName === oldBlock.config.name) { // rotate the block
 			if (oldBlock.config.rotatable) {
 				const rotate = (oldBlock.config.rotate + 1) % 4;
-				this.boardElement.placeBlock({x, y, type: blockName, rotate});
+				this.boardElement.placeBlock({x, y, type: oldBlock.config.name, rotate});
 			}
 		} else { // replace the block
 			// take the block from panel

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -405,24 +405,22 @@ class Stage {
 				const rotate = (oldBlock.config.rotate + 1) % 4;
 				this.boardElement.placeBlock({x, y, type: blockName, rotate});
 			}
-			return;
-		}
-
-		// take the block from panel
-		if (blockName !== 'empty') {
-			if (!this.panel.take(blockName)) { // lack the block, can't place it
-				return;
+		} else { // replace the block
+			// take the block from panel
+			if (blockName !== 'empty') {
+				if (!this.panel.take(blockName)) { // lack the block, can't place it
+					return;
+				}
 			}
-		}
 
-		// push the old block into panel
-		if (oldBlock.config.name !== 'empty') {
-			this.panel.push(oldBlock.config.name);
-		}
+			// push the old block into panel
+			if (oldBlock.config.name !== 'empty') {
+				this.panel.push(oldBlock.config.name);
+			}
 
-		this.boardElement.placeBlock({x, y, type: blockName, rotate: 0});
-		this.panel.update();
-		return;
+			this.boardElement.placeBlock({x, y, type: blockName, rotate: 0});
+			this.panel.update();
+		}
 	}
 }
 

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -22,7 +22,7 @@ class Stage {
 
 		this.board = new Board(this.config, this.blockSize);
 		this.boardElement = new BoardElement(this, this.board);
-		this.panel = new Panel(this);
+		this.panel = new Panel(this.config.parts, this.$stage.find('.panel'));
 
 		this.$ranking = this.$stage.siblings('.result-layer').find('.ranking');
 		this.$result = this.$stage.siblings('.result-layer').find('.result');
@@ -35,20 +35,18 @@ class Stage {
 
 		this.$stage.find('.statement').text(config.statement);
 
-		this.$selectedBlock = this.$stage.find('.panel .block[selected]').first();
-
 		this.$stage.find('.board .block').click((event) => {
 			const $block = $(event.target);
 			if (this.board.status === 'stop') {
-				const type = this.$selectedBlock.data('type');
-				this.panel.takeAndPlace($block.data('x'), $block.data('y'), type);
+				const type = this.panel.selected;
+				this.takeAndPlace($block.data('x'), $block.data('y'), type);
 			}
 		});
 
 		this.$stage.find('.board .block').bind('contextmenu', (event) => {
 			const $block = $(event.target);
 			if (this.board.status === 'stop') {
-				this.panel.takeAndPlace($block.data('x'), $block.data('y'), 'empty');
+				this.takeAndPlace($block.data('x'), $block.data('y'), 'empty');
 			}
 			return false;
 		});
@@ -376,14 +374,15 @@ class Stage {
 	clearBoard() {
 		this.board.blocks.forEach((row, x) => {
 			row.forEach((block, y) => {
-				this.panel.takeAndPlace(x, y, 'empty');
+				this.takeAndPlace(x, y, 'empty');
 			});
 		});
 	}
+
 	makeBoard(board) {
 		board.forEach((block) => {
 			for (let i = 0; i < block.rotate + 1; i++) {
-				this.panel.takeAndPlace(block.x, block.y, block.type);
+				this.takeAndPlace(block.x, block.y, block.type);
 			}
 		});
 	}
@@ -395,6 +394,35 @@ class Stage {
 		$register.text('ランキングに登録する');
 		$register.removeClass('success error');
 		$register.attr('disabled', false);
+	}
+
+	takeAndPlace(x, y, blockName) {
+		const oldBlock = this.board.getBlock(x, y);
+		assert(oldBlock, 'oldBlock is invalid');
+
+		if (blockName === oldBlock.config.name) { // rotate the block
+			if (oldBlock.config.rotatable) {
+				const rotate = (oldBlock.config.rotate + 1) % 4;
+				this.boardElement.placeBlock({x, y, type: blockName, rotate});
+			}
+			return;
+		}
+
+		// take the block from panel
+		if (blockName !== 'empty') {
+			if (!this.panel.take(blockName)) { // lack the block, can't place it
+				return;
+			}
+		}
+
+		// push the old block into panel
+		if (oldBlock.config.name !== 'empty') {
+			this.panel.push(oldBlock.config.name);
+		}
+
+		this.boardElement.placeBlock({x, y, type: blockName, rotate: 0});
+		this.panel.update();
+		return;
 	}
 }
 

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -400,7 +400,7 @@ class Stage {
 		const oldBlock = this.board.getBlock(x, y);
 		assert(oldBlock, 'oldBlock is invalid');
 
-		if (blockName === oldBlock.config.name) { // rotate the block
+		if (!blockName || blockName === oldBlock.config.name) { // rotate the block
 			if (oldBlock.config.rotatable) {
 				const rotate = (oldBlock.config.rotate + 1) % 4;
 				this.boardElement.placeBlock({x, y, type: blockName, rotate});
@@ -408,9 +408,7 @@ class Stage {
 		} else { // replace the block
 			// take the block from panel
 			if (blockName !== 'empty') {
-				if (!this.panel.take(blockName)) { // lack the block, can't place it
-					return;
-				}
+				this.panel.take(blockName);
 			}
 
 			// push the old block into panel
@@ -419,7 +417,6 @@ class Stage {
 			}
 
 			this.boardElement.placeBlock({x, y, type: blockName, rotate: 0});
-			this.panel.update();
 		}
 	}
 }


### PR DESCRIPTION
fix #159 。

あと、PanelがStageを参照しなくなった。


Panelのselectedがちょっと変わった。
もともとの動作では、
「選択されているblockが最後の一個であるとき、これがtakeAndPlaceによって取られると、（Panel#updateの効果により）selectedはundefinedにな」り、
これを踏まえて #74 に対するパッチ #77 では、selectedがundefinedのとき回転するようにしていた。（現masterのpanel.js:97）

しかしこのpatchでは、PanelのコンストラクタおよびPanel内のblockがクリックされたときのみselectedが変化するように変更され、（おそらく）selectedがundefinedになりえなくなった。

一応、人の手によるstage"四則演算5"での検証の結果、#74 もうまくいく気がしている。
（この #74 に対するfunctional test作りたい...けど #199 が先行するかなぁ。）