### PR TITLE
データの流れを直す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ Temporary Items
 *.css
 *.map
 *.sqlite3
+!/modals/anim.css

--- a/index.less
+++ b/index.less
@@ -1,5 +1,6 @@
 @import (inline) 'node_modules/normalize.css/normalize.css';
 @import (inline) 'node_modules/github-fork-ribbon-css/gh-fork-ribbon.css';
+@import (inline) 'modals/anim.css';
 
 .fixed-height(@height) {
 	flex: 0 0 @height;

--- a/modals/02/times-2.svg
+++ b/modals/02/times-2.svg
@@ -1,3 +1,5 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 	<image xlink:href="https://mnemo.pro/image/wireI.png" x="0" y="0" width="50" height="50"/>
 	<image xlink:href="https://mnemo.pro/image/times-2.png" x="0" y="0" width="50" height="50"/>

--- a/modals/02/times-2.svg
+++ b/modals/02/times-2.svg
@@ -1,36 +1,11 @@
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in {
-			animation: 2s linear infinite move-in;
-		}
-		@keyframes move-in {
-			0% {transform: translate(25px, -15px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out-down {
-			animation: 2s linear infinite move-out-down;
-		}
-		@keyframes move-out-down {
-			0% {
-				transform: translate(25px, 65px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(25px, 65px)}
-			100% {transform: translate(25px, 65px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/wireI.png" x="0" y="0" width="50" height="50"/>
 	<image xlink:href="https://mnemo.pro/image/times-2.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in">
+	<g class="data-in-top">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">8</text>
 	</g>
-	<g class="data-out-down">
+	<g class="data-out-bottom">
 		<rect x="-12" y="-10" width="24" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">16</text>
 	</g>

--- a/modals/04/add.svg
+++ b/modals/04/add.svg
@@ -1,51 +1,16 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in1 {
-			animation: 2s linear infinite move-in1;
-		}
-		@keyframes move-in1 {
-			0% {transform: translate(-15px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in2 {
-			animation: 2s linear infinite move-in2;
-		}
-		@keyframes move-in2 {
-			0% {transform: translate(65px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out {
-			animation: 2s linear infinite move-out;
-		}
-		@keyframes move-out {
-			0% {
-				transform: translate(25px, 65px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(25px, 65px)}
-			100% {transform: translate(25px, 65px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/add.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in1">
+	<g class="data-in-left">
 		<rect x="-10" y="-10" width="20" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">33</text>
 	</g>
-	<g class="data-in2">
+	<g class="data-in-right">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">4</text>
 	</g>
-	<g class="data-out">
+	<g class="data-out-bottom">
 		<rect x="-10" y="-10" width="20" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">37</text>
 	</g>

--- a/modals/04/wireT.svg
+++ b/modals/04/wireT.svg
@@ -1,52 +1,15 @@
 <?xml version="1.0"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in {
-			animation: 2s linear infinite move-in;
-		}
-		@keyframes move-in {
-			0% {transform: translate(25px, -15px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out1 {
-			animation: 2s linear infinite move-out1;
-		}
-		@keyframes move-out1 {
-			0% {
-				transform: translate(-15px, 25px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(-15px, 25px)}
-			100% {transform: translate(-15px, 25px)}
-		}
-		.data-out2 {
-			animation: 2s linear infinite move-out2;
-		}
-		@keyframes move-out2 {
-			0% {
-				transform: translate(65px, 25px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(65px, 25px)}
-			100% {transform: translate(65px, 25px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/wireT.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in">
+	<g class="data-in-top">
 		<rect x="-10" y="-10" width="20" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">42</text>
 	</g>
-	<g class="data-out1">
+	<g class="data-out-left">
 		<rect x="-10" y="-10" width="20" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">42</text>
 	</g>
-	<g class="data-out2">
+	<g class="data-out-right">
 		<rect x="-10" y="-10" width="20" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">42</text>
 	</g>

--- a/modals/04/wireT.svg
+++ b/modals/04/wireT.svg
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 	<image xlink:href="https://mnemo.pro/image/wireT.png" x="0" y="0" width="50" height="50"/>
 	<g class="data-in-top">

--- a/modals/anim.css
+++ b/modals/anim.css
@@ -1,0 +1,92 @@
+.data-in-top {
+  animation: 2s linear infinite move-in-top;
+}
+@keyframes move-in-top {
+  0% {transform: translate(25px, -15px)}
+  40% {
+    transform: translate(25px, 25px);
+    animation-timing-function: steps(1, start);
+  }
+  100% {transform: translate(25px, -15px)}
+}
+.data-in-left {
+  animation: 2s linear infinite move-in-left;
+}
+@keyframes move-in-left {
+  0% {transform: translate(-15px, 25px)}
+  40% {
+    transform: translate(25px, 25px);
+    animation-timing-function: steps(1, start);
+  }
+  100% {transform: translate(-15px, 25px)}
+}
+.data-in-right {
+  animation: 2s linear infinite move-in-right;
+}
+@keyframes move-in-right {
+  0% {transform: translate(65px, 25px)}
+  40% {
+    transform: translate(25px, 25px);
+    animation-timing-function: steps(1, start);
+  }
+  100% {transform: translate(65px, 25px)}
+}
+.data-in-bottom {
+  animation: 2s linear infinite move-in-bottom;
+}
+@keyframes move-in-bottom {
+  0% {transform: translate(25px, 65px)}
+  40% {
+    transform: translate(25px, 25px);
+    animation-timing-function: steps(1, start);
+  }
+  100% {transform: translate(25px, 65px)}
+}
+.data-out-top {
+  animation: 2s linear infinite move-out-top;
+}
+@keyframes move-out-top {
+  0% {
+    transform: translate(25px, -15px);
+    animation-timing-function: steps(1, end);
+  }
+  40% {transform: translate(25px, 25px)}
+  80% {transform: translate(25px, -15px)}
+  100% {transform: translate(25px, -15px)}
+}
+.data-out-left {
+  animation: 2s linear infinite move-out-left;
+}
+@keyframes move-out-left {
+  0% {
+    transform: translate(-15px, 25px);
+    animation-timing-function: steps(1, end);
+  }
+  40% {transform: translate(25px, 25px)}
+  80% {transform: translate(-15px, 25px)}
+  100% {transform: translate(-15px, 25px)}
+}
+.data-out-right {
+  animation: 2s linear infinite move-out-right;
+}
+@keyframes move-out-right {
+  0% {
+    transform: translate(65px, 25px);
+    animation-timing-function: steps(1, end);
+  }
+  40% {transform: translate(25px, 25px)}
+  80% {transform: translate(65px, 25px)}
+  100% {transform: translate(65px, 25px)}
+}
+.data-out-bottom {
+  animation: 2s linear infinite move-out-bottom;
+}
+@keyframes move-out-bottom {
+  0% {
+    transform: translate(25px, 65px);
+    animation-timing-function: steps(1, end);
+  }
+  40% {transform: translate(25px, 25px)}
+  80% {transform: translate(25px, 65px)}
+  100% {transform: translate(25px, 65px)}
+}

--- a/modals/anim.css
+++ b/modals/anim.css
@@ -1,92 +1,92 @@
 .data-in-top {
-  animation: 2s linear infinite move-in-top;
+	animation: 2s linear infinite move-in-top;
 }
 @keyframes move-in-top {
-  0% {transform: translate(25px, -15px)}
-  40% {
-    transform: translate(25px, 25px);
-    animation-timing-function: steps(1, start);
-  }
-  100% {transform: translate(25px, -15px)}
+	0% {transform: translate(25px, -15px)}
+	40% {
+		transform: translate(25px, 25px);
+		animation-timing-function: steps(1, start);
+	}
+	100% {transform: translate(25px, -15px)}
 }
 .data-in-left {
-  animation: 2s linear infinite move-in-left;
+	animation: 2s linear infinite move-in-left;
 }
 @keyframes move-in-left {
-  0% {transform: translate(-15px, 25px)}
-  40% {
-    transform: translate(25px, 25px);
-    animation-timing-function: steps(1, start);
-  }
-  100% {transform: translate(-15px, 25px)}
+	0% {transform: translate(-15px, 25px)}
+	40% {
+		transform: translate(25px, 25px);
+		animation-timing-function: steps(1, start);
+	}
+	100% {transform: translate(-15px, 25px)}
 }
 .data-in-right {
-  animation: 2s linear infinite move-in-right;
+	animation: 2s linear infinite move-in-right;
 }
 @keyframes move-in-right {
-  0% {transform: translate(65px, 25px)}
-  40% {
-    transform: translate(25px, 25px);
-    animation-timing-function: steps(1, start);
-  }
-  100% {transform: translate(65px, 25px)}
+	0% {transform: translate(65px, 25px)}
+	40% {
+		transform: translate(25px, 25px);
+		animation-timing-function: steps(1, start);
+	}
+	100% {transform: translate(65px, 25px)}
 }
 .data-in-bottom {
-  animation: 2s linear infinite move-in-bottom;
+	animation: 2s linear infinite move-in-bottom;
 }
 @keyframes move-in-bottom {
-  0% {transform: translate(25px, 65px)}
-  40% {
-    transform: translate(25px, 25px);
-    animation-timing-function: steps(1, start);
-  }
-  100% {transform: translate(25px, 65px)}
+	0% {transform: translate(25px, 65px)}
+	40% {
+		transform: translate(25px, 25px);
+		animation-timing-function: steps(1, start);
+	}
+	100% {transform: translate(25px, 65px)}
 }
 .data-out-top {
-  animation: 2s linear infinite move-out-top;
+	animation: 2s linear infinite move-out-top;
 }
 @keyframes move-out-top {
-  0% {
-    transform: translate(25px, -15px);
-    animation-timing-function: steps(1, end);
-  }
-  40% {transform: translate(25px, 25px)}
-  80% {transform: translate(25px, -15px)}
-  100% {transform: translate(25px, -15px)}
+	0% {
+		transform: translate(25px, -15px);
+		animation-timing-function: steps(1, end);
+	}
+	40% {transform: translate(25px, 25px)}
+	80% {transform: translate(25px, -15px)}
+	100% {transform: translate(25px, -15px)}
 }
 .data-out-left {
-  animation: 2s linear infinite move-out-left;
+	animation: 2s linear infinite move-out-left;
 }
 @keyframes move-out-left {
-  0% {
-    transform: translate(-15px, 25px);
-    animation-timing-function: steps(1, end);
-  }
-  40% {transform: translate(25px, 25px)}
-  80% {transform: translate(-15px, 25px)}
-  100% {transform: translate(-15px, 25px)}
+	0% {
+		transform: translate(-15px, 25px);
+		animation-timing-function: steps(1, end);
+	}
+	40% {transform: translate(25px, 25px)}
+	80% {transform: translate(-15px, 25px)}
+	100% {transform: translate(-15px, 25px)}
 }
 .data-out-right {
-  animation: 2s linear infinite move-out-right;
+	animation: 2s linear infinite move-out-right;
 }
 @keyframes move-out-right {
-  0% {
-    transform: translate(65px, 25px);
-    animation-timing-function: steps(1, end);
-  }
-  40% {transform: translate(25px, 25px)}
-  80% {transform: translate(65px, 25px)}
-  100% {transform: translate(65px, 25px)}
+	0% {
+		transform: translate(65px, 25px);
+		animation-timing-function: steps(1, end);
+	}
+	40% {transform: translate(25px, 25px)}
+	80% {transform: translate(65px, 25px)}
+	100% {transform: translate(65px, 25px)}
 }
 .data-out-bottom {
-  animation: 2s linear infinite move-out-bottom;
+	animation: 2s linear infinite move-out-bottom;
 }
 @keyframes move-out-bottom {
-  0% {
-    transform: translate(25px, 65px);
-    animation-timing-function: steps(1, end);
-  }
-  40% {transform: translate(25px, 25px)}
-  80% {transform: translate(25px, 65px)}
-  100% {transform: translate(25px, 65px)}
+	0% {
+		transform: translate(25px, 65px);
+		animation-timing-function: steps(1, end);
+	}
+	40% {transform: translate(25px, 25px)}
+	80% {transform: translate(25px, 65px)}
+	100% {transform: translate(25px, 65px)}
 }

--- a/modals/conditionals/conditional0.svg
+++ b/modals/conditionals/conditional0.svg
@@ -1,66 +1,20 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in1 {
-			animation: 2s linear infinite move-in1;
-		}
-		@keyframes move-in1 {
-			0% {transform: translate(25px, -15px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in2 {
-			animation: 2s linear infinite move-in2;
-		}
-		@keyframes move-in2 {
-			0% {transform: translate(-15px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in3 {
-			animation: 2s linear infinite move-in3;
-		}
-		@keyframes move-in3 {
-			0% {transform: translate(65px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out-down {
-			animation: 2s linear infinite move-out-down;
-		}
-		@keyframes move-out-down {
-			0% {
-				transform: translate(25px, 65px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(25px, 65px)}
-			100% {transform: translate(25px, 65px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/conditional.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in1">
+	<g class="data-in-top">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">0</text>
 	</g>
-	<g class="data-in2">
+	<g class="data-in-left">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>
-	<g class="data-in3">
+	<g class="data-in-right">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">7</text>
 	</g>
-	<g class="data-out-down">
+	<g class="data-out-bottom">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">7</text>
 	</g>

--- a/modals/conditionals/conditional1.svg
+++ b/modals/conditionals/conditional1.svg
@@ -1,66 +1,20 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in1 {
-			animation: 2s linear infinite move-in1;
-		}
-		@keyframes move-in1 {
-			0% {transform: translate(25px, -15px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in2 {
-			animation: 2s linear infinite move-in2;
-		}
-		@keyframes move-in2 {
-			0% {transform: translate(-15px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in3 {
-			animation: 2s linear infinite move-in3;
-		}
-		@keyframes move-in3 {
-			0% {transform: translate(65px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out-down {
-			animation: 2s linear infinite move-out-down;
-		}
-		@keyframes move-out-down {
-			0% {
-				transform: translate(25px, 65px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(25px, 65px)}
-			100% {transform: translate(25px, 65px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/conditional.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in1">
+	<g class="data-in-top">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">1</text>
 	</g>
-	<g class="data-in2">
+	<g class="data-in-left">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>
-	<g class="data-in3">
+	<g class="data-in-right">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">7</text>
 	</g>
-	<g class="data-out-down">
+	<g class="data-out-bottom">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>

--- a/modals/conditionals/transistor0.svg
+++ b/modals/conditionals/transistor0.svg
@@ -1,51 +1,16 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in1 {
-			animation: 2s linear infinite move-in1;
-		}
-		@keyframes move-in1 {
-			0% {transform: translate(25px, -15px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in2 {
-			animation: 2s linear infinite move-in2;
-		}
-		@keyframes move-in2 {
-			0% {transform: translate(-15px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out-down {
-			animation: 2s linear infinite move-out-down;
-		}
-		@keyframes move-out-down {
-			0% {
-				transform: translate(25px, 65px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(25px, 65px)}
-			100% {transform: translate(25px, 65px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/transistor.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in1">
+	<g class="data-in-top">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">0</text>
 	</g>
-	<g class="data-in2">
+	<g class="data-in-left">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>
-	<g class="data-out-down">
+	<g class="data-out-bottom">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>

--- a/modals/conditionals/transistor1.svg
+++ b/modals/conditionals/transistor1.svg
@@ -1,51 +1,16 @@
 <?xml version="1.0"?>
+<?xml-stylesheet type="text/css" href="../anim.css"?>
 <svg width="50" height="50" viewPort="0 0 50 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-	<style>
-		.data-in1 {
-			animation: 2s linear infinite move-in1;
-		}
-		@keyframes move-in1 {
-			0% {transform: translate(25px, -15px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-in2 {
-			animation: 2s linear infinite move-in2;
-		}
-		@keyframes move-in2 {
-			0% {transform: translate(-15px, 25px)}
-			40% {
-				transform: translate(25px, 25px);
-				animation-timing-function: steps(1, start);
-			}
-			100% {transform: translate(25px, -15px)}
-		}
-		.data-out {
-			animation: 2s linear infinite move-out;
-		}
-		@keyframes move-out {
-			0% {
-				transform: translate(25px, 65px);
-				animation-timing-function: steps(1, end);
-			}
-			40% {transform: translate(25px, 25px)}
-			80% {transform: translate(65px, 25px)}
-			100% {transform: translate(65px, 25px)}
-		}
-	</style>
 	<image xlink:href="https://mnemo.pro/image/transistor.png" x="0" y="0" width="50" height="50"/>
-	<g class="data-in1">
+	<g class="data-in-top">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">1</text>
 	</g>
-	<g class="data-in2">
+	<g class="data-in-left">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>
-	<g class="data-out">
+	<g class="data-out-right">
 		<rect x="-8" y="-10" width="16" height="20" rx="5" ry="5" fill="#ff8c00"/>
 		<text x="0" y="7" text-anchor="middle" font-size="14" font-weight="bold" fill="white">3</text>
 	</g>


### PR DESCRIPTION
Fix #226.

クラス名を `data-in-top` みたいにしてSVG間で統一しました。統一したのでスタイルをCSSファイル `/modals/anim.css` にまとめました。
SVG内の `<?xml-stylesheet 〜〜?>` はSVGファイル単独で見たとき用で、`index.less`側で別にCSSファイルをimportしてます。

現状、XML宣言と `<?xml-stylesheet 〜〜?>` がHTMLにそのまま書き出されているんですが、ブラウザに無視されているものの、しかし気持ち悪いですよね……（というかinvalidなのでアレ）