### PR TITLE
Travis CI でのテスト実行にYarnを使用

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 # yarn upgrade will also install missing packages as well
 install:
-  # Fake lockfile *puke*
+  # Yarn needs lockfile to exist even if --no-lockfile option is provided. So... fake lockfile *puke*
   - touch yarn.lock
   - yarn upgrade --no-lockfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ install:
   - yarn upgrade --no-lockfile
 
 script:
-  - npm run build:production
-  - npm test
-  - npm run test:api
+  - yarn build:production
+  - yarn test
+  - yarn test:api
 
 after_success:
-  - npm run coveralls
+  - yarn coveralls
   - bash bin/deploy.sh
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,19 @@ addons:
 before_install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  # Install yarn
+  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+
+install: yarn install
 
 script:
   - npm run build:production
   - npm test
   - npm run test:api
+
 after_success:
   - npm run coveralls
   - bash bin/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
 # yarn upgrade will also install missing packages as well
-install: yarn upgrade
+install: yarn upgrade --no-lockfile
 
 script:
   - ls -lah node_modules/.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ before_install:
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
 # yarn upgrade will also install missing packages as well
-install: yarn upgrade --no-lockfile
+install:
+  # Fake lockfile *puke*
+  - touch yarn.lock
+  - yarn upgrade --no-lockfile
 
 script:
   - ls -lah node_modules/.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ before_install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
-install: yarn install
+# yarn upgrade will also install missing packages as well
+install: yarn upgrade
 
 script:
   - ls -lah node_modules/.bin
@@ -32,6 +33,11 @@ script:
 after_success:
   - npm run coveralls
   - bash bin/deploy.sh
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,29 @@ language: node_js
 node_js:
   - node
 
+sudo: false
+
+# Setup xvfb
 # https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
+# Install yarn
+# https://github.com/travis-ci/travis-ci/issues/6720#issuecomment-285981417
 addons:
   apt:
+    sources:
+      - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
+        key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
     packages:
       - xvfb
+      - yarn
+
 before_install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-  # Install yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
 
 install: yarn install
 
 script:
+  - ls -lah node_modules/.bin
   - npm run build:production
   - npm test
   - npm run test:api

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - node
 
+dist: trusty
 sudo: false
 
 # Setup xvfb
@@ -28,7 +29,6 @@ install:
   - yarn upgrade --no-lockfile
 
 script:
-  - ls -lah node_modules/.bin
   - npm run build:production
   - npm test
   - npm run test:api

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "jquery": "^3.0.0",
     "less": "^2.7.1",
     "mathjs": "^3.8.0",
+    "mocha": "^3.3.0",
     "mocha-logger": "^1.0.4",
     "mochify": "^3.1.0",
     "mochify-istanbul": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "replace": "^0.3.0",
     "sequelize-cli": "^2.4.0",
     "sqlite3": "^3.1.4",
-    "uglifyify": "^3.0.3",
+    "uglify-js": "^2.8.22",
     "umzug": "^1.11.0",
     "watchify": "^3.7.0"
   },


### PR DESCRIPTION
Travis環境にyarnをインストールし、node_modulesとかyarn-cacheとかをキャッシュするようにした。早くなったかは微妙だけどリモートサーバーへの負荷は軽くなるはず。

ついでにsubdependencyに依存していたやつをdependencyにした。

ついでにPreciseのサポートが切れたのでTrustyにした。