### PR TITLE
中央値ステージをランダム化

### DIFF
--- a/lib/stage.js
+++ b/lib/stage.js
@@ -228,7 +228,7 @@ class Stage {
 						return x.toString();
 					}
 
-					return `[${x.map((y) => y === null ? '???' : y).join(',')}]`;
+					return `[${x.map((y) => y === null ? '?' : y).join(',')}]`;
 				}).join(', ');
 			}
 

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -221,11 +221,14 @@ class Stage {
 				inputString = input.toString();
 			} else {
 				inputString = input.map((x) => {
+					if (x === null) {
+						return '???';
+					}
 					if (typeof x === 'number') {
 						return x.toString();
 					}
 
-					return `[${x.join(',')}]`;
+					return `[${x.map((y) => y === null ? '???' : y).join(',')}]`;
 				}).join(', ');
 			}
 

--- a/stages/the-fifth-max.js
+++ b/stages/the-fifth-max.js
@@ -65,57 +65,129 @@ module.exports = {
 		[
 			5,
 			[
-				0,
-				1,
-				-1,
-				2,
-				-2,
+				null,
+				null,
+				null,
+				null,
+				null,
 			],
 		],
 		[
 			7,
 			[
-				51,
-				90,
-				20,
-				30,
-				1,
-				60,
-				81,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
 			],
 		],
 		[
 			7,
 			[
-				67,
-				90,
-				46,
-				99,
-				59,
-				23,
-				66,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
 			],
 		],
 		[
 			7,
 			[
-				22,
-				89,
-				48,
-				20,
-				88,
-				39,
-				22,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
+				null,
 			],
 		],
 	],
 	output: [
 		3,
-		0,
-		51,
-		66,
-		39,
+		null,
+		null,
+		null,
+		null,
 	],
+	ioGenerator: (random) => {
+		const getMedian = (input) => input.slice(0).sort((a, b) => a - b)[(input.length - 1) / 2];
+
+		const isMedianUnique = (input) => {
+			const median = getMedian(input);
+			let count = 0;
+			input.forEach((x) => {
+				if (x === median) {
+					count++;
+				}
+			});
+			return count === 1;
+		};
+
+		const inputs = [
+			[1, 2, 3, 4, 5],
+		];
+
+		// 5 numbers in -5..5
+		inputs.push((() => {
+			let input = null;
+
+			do {
+				input = Array.from({length: 5}, () => -5 + Math.floor(random() * 11));
+			} while (!isMedianUnique(input));
+
+			return input;
+		})());
+
+		// 7 numbers in 1..100
+		inputs.push((() => {
+			let input = null;
+
+			do {
+				input = Array.from({length: 7}, () => 1 + Math.floor(random() * 100));
+			} while (!isMedianUnique(input));
+
+			return input;
+		})());
+
+		// 7 numbers in 0..49
+		inputs.push((() => {
+			let input = null;
+
+			do {
+				input = Array.from({length: 7}, () => Math.floor(random() * 50));
+			} while (!isMedianUnique(input));
+
+			return input;
+		})());
+
+		// 7 numbers in 50..99, the median is at last
+		inputs.push((() => {
+			let input = null;
+
+			do {
+				input = Array.from({length: 7}, () => 50 + Math.floor(random() * 50));
+			} while (!isMedianUnique(input));
+
+			// Swap the median and the last
+			const median = getMedian(input);
+			input[input.indexOf(median)] = input[6];
+			input[6] = median;
+
+			return input;
+		})());
+
+		return {
+			input: inputs.map((input) => [input.length, input]),
+			output: inputs.map((input) => getMedian(input)),
+		};
+	},
 	width: 31,
 	height: 31,
 	clockLimit: 2000,

--- a/stages/the-fifth-max.js
+++ b/stages/the-fifth-max.js
@@ -1,6 +1,6 @@
 module.exports = {
 	name: 'the-fifth-max',
-	version: 3,
+	version: 4,
 	parts: {
 		wireI: null,
 		wireL: null,

--- a/stages/the-fifth-max.js
+++ b/stages/the-fifth-max.js
@@ -121,13 +121,7 @@ module.exports = {
 
 		const isMedianUnique = (input) => {
 			const median = getMedian(input);
-			let count = 0;
-			input.forEach((x) => {
-				if (x === median) {
-					count++;
-				}
-			});
-			return count === 1;
+			return input.filter((x) => x === median).length === 1;
 		};
 
 		const inputs = [
@@ -135,40 +129,40 @@ module.exports = {
 		];
 
 		// 5 numbers in -5..5
-		inputs.push((() => {
+		{
 			let input = null;
 
 			do {
 				input = Array.from({length: 5}, () => -5 + Math.floor(random() * 11));
 			} while (!isMedianUnique(input));
 
-			return input;
-		})());
+			inputs.push(input);
+		}
 
 		// 7 numbers in 1..100
-		inputs.push((() => {
+		{
 			let input = null;
 
 			do {
 				input = Array.from({length: 7}, () => 1 + Math.floor(random() * 100));
 			} while (!isMedianUnique(input));
 
-			return input;
-		})());
+			inputs.push(input);
+		}
 
 		// 7 numbers in 0..49
-		inputs.push((() => {
+		{
 			let input = null;
 
 			do {
 				input = Array.from({length: 7}, () => Math.floor(random() * 50));
 			} while (!isMedianUnique(input));
 
-			return input;
-		})());
+			inputs.push(input);
+		}
 
 		// 7 numbers in 50..99, the median is at last
-		inputs.push((() => {
+		{
 			let input = null;
 
 			do {
@@ -180,8 +174,8 @@ module.exports = {
 			input[input.indexOf(median)] = input[6];
 			input[6] = median;
 
-			return input;
-		})());
+			inputs.push(input);
+		}
 
 		return {
 			input: inputs.map((input) => [input.length, input]),

--- a/test/unit/stages.ls
+++ b/test/unit/stages.ls
@@ -19,6 +19,7 @@ require! {
   '../../stages/sqrt-hard'
   '../../stages/msd'
   '../../stages/mod3-hard'
+  '../../stages/the-fifth-max'
   '../../stages/repeat-self'
   '../../stages/fibonacci-hard'
   '../../stages/factorization'
@@ -53,6 +54,13 @@ io-spec = ({input, output}) ->
   expect output .to.all.satisfy integrality
 
   expect input .to.have.length output.length
+
+io-spec-seq = ({input, output}) ->
+  expect {input, output} .to.satisfy io-spec
+
+  expect input .to.all.satisfy (i) ->
+    expect i .to.be.an \array .that.has.length-of 2
+    expect i.1 .to.be.an \array .that.has.length-of i.0
 
 sum-of-digits = (n) -> n.to-string!split '' .map (parse-int _, 10) .reduce (+)
 
@@ -268,6 +276,24 @@ describe 'Stage Data' ->
       expect io.output.0 .to.equal 0
       expect io.output.1 .to.equal 1
       expect io.output.2 .to.equal 2
+
+  describe 'the-fifth-max stage' ->
+    It 'generates medians' ->
+      io = the-fifth-max.io-generator @random
+
+      expect io .to.satisfy io-spec-seq
+
+      expect zip io.input, io.output .to.all.satisfy ([input, output]) ->
+        output is mathjs.median input.1 and input.1.filter (is output) .length is 1
+
+      expect io.input.0 .to.deep.equal [5, [1, 2, 3, 4, 5]]
+
+      expect io.input.1.0 .to.equal 5
+      expect io.input.2.0 .to.equal 7
+      expect io.input.3.0 .to.equal 7
+      expect io.input.4.0 .to.equal 7
+
+      expect io.input.4.1.6 .to.equal mathjs.median io.input.4.1
 
   describe 'repeat-self stage' ->
     It 'generates valid io' ->


### PR DESCRIPTION
嘘解法(あいつ)ら……駆逐してやる！　この世から……一つ残らず！

- 入力がランダムなときに「???」と表示されるのを複数入力・配列入力にも対応
  - 配列については、複数並ぶとなると「???」は長すぎる気がしたので「?」にしてみました
- テストに配列入力用の `io-spec-seq` を追加（`io-spec` に加えて、複数入力の左側が右側の配列の要素数になっていることを確認します）
- 中央値ステージの最後の入力ケースは、中央値が配列の最後に来るため（既知の解法では）ワーストケースになります