### PR TITLE
枝刈り step & hand

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -259,9 +259,11 @@ class Board extends EventEmitter {
 		};
 
 		this.forBlocks((block) => {
-			block.on('pass', onBlockPass);
-			block.step();
-			block.removeListener('pass', onBlockPass);
+			if (block.inputExists) {
+				block.on('pass', onBlockPass);
+				block.step();
+				block.removeListener('pass', onBlockPass);
+			}
 		});
 
 		this.clock++;
@@ -281,7 +283,11 @@ class Board extends EventEmitter {
 	}
 
 	hand() {
-		this.forBlocks((block) => block.hand());
+		this.forBlocks((block) => {
+			if (block.outputExists) {
+				block.hand();
+			}
+		});
 
 		let inputExists = false;
 		this.forBlocks((block) => {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "npm run unit && npm run functional && npm run lint",
     "api:init": "cd api && sequelize db:migrate:undo:all && sequelize db:migrate && sequelize db:seed:all",
     "api": "cd api && node index.js",
-    "test:api": "cd api && cross-env NODE_ENV=test istanbul cover ../node_modules/mocha/bin/_mocha -- --recursive"
+    "test:api": "cd api && cross-env NODE_ENV=test istanbul cover ../node_modules/mocha/bin/_mocha -- --recursive",
+    "bench": "lsc benchmark/index.ls"
   },
   "repository": {
     "type": "git",
@@ -88,6 +89,7 @@
     "less": "^2.7.1",
     "livescript-loader": "^0.1.6",
     "mathjs": "^3.8.0",
+    "microtime": "^2.1.6",
     "mocha": "^3.3.0",
     "mocha-logger": "^1.0.4",
     "mocha-webpack": "^0.7.0",


### PR DESCRIPTION
#150 のBoard#runの高速化。

前回の #207 では、inputExists, outputExistsの計算を枝刈りなどして高速化したんだが、
そういえばせっかく各ブロックに対してinputExists, outputExistsを生やしたので、
stepやhand（いつのまにかあちこちのpassがhandに変わってますね）でforBlock回すときに、
それ使えんじゃんっていう。

package.jsonに
```
"bench": "mocha \"benchmark/index.ls\" --reporter spec --compilers ls:livescript",
```
を生やして、`npm run bench`をすると、18sec -> 7.5secくらいに改善。
まあたぶん、このbenchmark/index.lsのボードだと、dataを持っているブロックって各clockで高々2個だからね。
