### PR TITLE
escape calc in less

### DIFF
--- a/index.less
+++ b/index.less
@@ -118,10 +118,9 @@ button {
 
 		@keyframes slide {
 			from {
-				transform: translateX(0);
 			}
 			to {
-				transform: translateX(calc(-100vw - 100%));
+				transform: translateX(calc(~"-100vw - 100%"));
 			}
 		}
 
@@ -1178,7 +1177,7 @@ button {
 
 			@keyframes ranking-animate {
 				from {
-					transform: translate(-50%, calc(-50% + 100px));
+					transform: translate(-50%, calc(~"-50% + 100px"));
 					opacity: 0;
 				}
 				to {

--- a/index.less
+++ b/index.less
@@ -118,6 +118,7 @@ button {
 
 		@keyframes slide {
 			from {
+				transform: translateX(0);
 			}
 			to {
 				transform: translateX(calc(~"-100vw - 100%"));


### PR DESCRIPTION
fix #212 

```
@keyframes slide { to { transform }}
@keyframes ranking-animate { from { transform }}
```

の中にあるcalcをescapeした。

slideの方は、.cloudの流れのアニメーションのものだが、
もともと-200vwにcalcされていたのが、-100vw - 100%になって、たぶん今のところ結果は変わらないと思う。たぶん。

ranking-animateの方は、ランキング表示時に下からスッと透明度を減らしながら表示してくるアニメーションのもので、
今までよりもスッと動く幅が小さくなった。まあそれだけなので、いいんじゃないかな。