### PR TITLE
Explicitly exec yarn install on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,9 @@ before_install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
-# yarn upgrade will also install missing packages as well
 install:
-  # Yarn needs lockfile to exist even if --no-lockfile option is provided. So... fake lockfile *puke*
-  - touch yarn.lock
-  - yarn upgrade --no-lockfile
+  - yarn install
+  - yarn upgrade
 
 script:
   - yarn build:production


### PR DESCRIPTION
Fixes #351.

Yarn 1.0 リリースに伴って `yarn upgrade` がlockfileなしで動かなくなったので、明示的に `yarn install` を実行してyarn.lockを生成するようにした。

ビルドが少し重くなる (と思う) けど、もともとトリッキーなやり方だったので致し方なし。