### PR TITLE
Node v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "^8.6.0"
+    "node": "^9.0.0"
   },
   "scripts": {
     "js": "cross-env BABEL_ENV=debug webpack",


### PR DESCRIPTION
Closes #373.

[リリースノート](https://nodejs.org/en/blog/release/v9.0.0/)でかすぎて読めないけどまあ大丈夫やろw