### PR TITLE
enzyme-adapter-utilsのバージョンを固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "request": "^2.81.0",
     "seedrandom": "^2.4.2",
     "sequelize": "^4.0.0"
+  },
+  "resolutions": {
+    "enzyme-adapter-react-16/enzyme-adapter-utils": "1.0.1"
   }
 }


### PR DESCRIPTION
Closes #375, closes #376, and closes #377.

なぜかenzyme-adapter-react-16下のenzyme-adapter-utilsを1.0.1から1.1.0にアップデートするとビルドがスタックするので、[Selective dependency resolutions](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/) 機能を用いてバージョンを固定。

バージョン管理上あまりよろしくないのでなんでビルドが落ちるのかは要調査。