### PR TITLE
テストを通す webpack-sources 1.0.1を固定、core-jsのrequireを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "sequelize": "^4.0.0"
   },
   "resolutions": {
-    "enzyme-adapter-react-16/enzyme-adapter-utils": "1.0.1",
     "webpack/webpack-sources": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "sequelize": "^4.0.0"
   },
   "resolutions": {
-    "enzyme-adapter-react-16/enzyme-adapter-utils": "1.0.1"
+    "enzyme-adapter-react-16/enzyme-adapter-utils": "1.0.1",
+    "webpack/webpack-sources": "1.0.1"
   }
 }

--- a/test/unit/block.ls
+++ b/test/unit/block.ls
@@ -1,6 +1,5 @@
 require! {
   chai: {expect}
-  # Shims for phantomjs environment
   '../../lib/board': Board
   '../../lib/block': Block
   '../../lib/data': Data

--- a/test/unit/block.ls
+++ b/test/unit/block.ls
@@ -1,7 +1,6 @@
 require! {
   chai: {expect}
   # Shims for phantomjs environment
-  'core-js'
   '../../lib/board': Board
   '../../lib/block': Block
   '../../lib/data': Data

--- a/test/unit/stages.ls
+++ b/test/unit/stages.ls
@@ -3,7 +3,6 @@ require! {
   'chai-things'
   mathjs # as reference implementation
   seedrandom
-  'core-js'
   '../../stages/calc03'
   '../../stages/conditional01'
   '../../stages/conditional02'


### PR DESCRIPTION
resolve #379, resolve #380, resolve #381, resolve #382, resolve #383, resolve #384, resolve #385, resolve #386, resolve #387, resolve #388, resolve #389, resolve #390, resolve #391

まず、webpackのdepのwebpack-sources 1.0.2がなんか具合が悪いっぽいので、1.0.1に固定。早く治ってほしいな。
ttps://github.com/webpack/webpack-sources/issues/28

あと、テストの中のblock.lsとかのrequire! 'core-js'が変なものを入れるせいで、
enzyme-adapter-utillsのバージョンを上げるとテストが失敗するようになっていたので、このrequireを削除。
PhantomJSのときのものだったらしい。

resolutionsが-1/+1という感じ。