### PR TITLE
自己申告点数を利用して、ユーザ重複時のvalidateを省略する

### DIFF
--- a/api/routes/stages.js
+++ b/api/routes/stages.js
@@ -67,13 +67,7 @@ router.get('/:stage/submissions', async (req, res) => {
 
 router.post('/:stage/submissions', async (req, res) => {
 	const stageName = req.params.stage;
-	if (typeof stageName !== 'string') {
-		res.status(400).json({
-			error: true,
-			message: 'malicious stageName',
-		});
-		return;
-	}
+
 	const stageDatum = stageData.find((s) => s.name === stageName);
 	if (typeof stageDatum === 'undefined') {
 		res.status(404).json({

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -350,6 +350,20 @@ describe('/stages', () => {
 			}
 		});
 
+		it('reports 500 error when stage is not found in DB', async () => {
+			try {
+				// FIXME 'calc01' is magic stage name...
+				await chai.request(app).post('/stages/calc01/submissions').send({
+					name: 'hakatashi',
+					board: validBoard,
+					score: validBoardScore,
+				});
+				expect.fail();
+			} catch (res) {
+				expect(res).to.have.status(500);
+			}
+		});
+
 		it('reports 400 error when attempted to post invalid board', async () => {
 			try {
 				await chai.request(app).post('/stages/wire01/submissions').send({

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -20,6 +20,7 @@ const Stages = require('../../models/stage');
 const Submissions = require('../../models/submission');
 const stageData = require('../../../stages');
 const {nop} = require('../../../lib/util');
+const {calculateScore} = require('../../../lib/validator');
 const wire01 = stageData.find((stageDatum) => stageDatum.name === 'wire01');
 
 const umzug = new Umzug({
@@ -268,6 +269,11 @@ describe('/stages', () => {
 			type: 'wireI',
 			rotate: 0,
 		}];
+		const validBoardScore = calculateScore({
+			clocks: 3,
+			blocks: 3,
+			stage: wire01,
+		});
 
 		const invalidBoard = [{
 			x: 1,
@@ -285,6 +291,11 @@ describe('/stages', () => {
 			type: 'wireI',
 			rotate: 0,
 		}];
+		const invalidBoardScore = calculateScore({
+			clocks: 3,
+			blocks: 3,
+			stage: wire01,
+		});
 
 		const lowerScoreBoard = [{
 			x: 1,
@@ -307,6 +318,15 @@ describe('/stages', () => {
 			type: 'wireI',
 			rotate: 0,
 		}];
+		const lowerScoreBoardScore = calculateScore({
+			clocks: 3,
+			blocks: 4,
+			stage: wire01,
+		});
+
+		before(async () => {
+			expect(validBoardScore).to.equal(10000);
+		});
 
 		beforeEach(async () => {
 			stage = await Stages.create({
@@ -322,6 +342,7 @@ describe('/stages', () => {
 				await chai.request(app).post('/stages/hoge/submissions').send({
 					name: 'hakatashi',
 					board: validBoard,
+					score: validBoardScore,
 				});
 				expect.fail();
 			} catch (res) {
@@ -334,6 +355,7 @@ describe('/stages', () => {
 				await chai.request(app).post('/stages/wire01/submissions').send({
 					name: 'hakatashi',
 					board: invalidBoard,
+					score: invalidBoardScore,
 				});
 				expect.fail();
 			} catch (res) {
@@ -346,6 +368,7 @@ describe('/stages', () => {
 				await chai.request(app).post('/stages/wire01/submissions').send({
 					name: {$ne: 'attacker'},
 					board: validBoard,
+					score: validBoardScore,
 				});
 				expect.fail();
 			} catch (res) {
@@ -357,11 +380,12 @@ describe('/stages', () => {
 			const res = await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'satos',
 				board: validBoard,
+				score: validBoardScore,
 			});
 			expect(res).to.have.status(200);
 			expect(res).to.be.json;
 			expect(res.body.name).to.equal('satos');
-			expect(res.body.score).to.equal(10000);
+			expect(res.body.score).to.equal(validBoardScore);
 			expect(res.body.blocks).to.equal(3);
 			expect(res.body.version).to.equal(wire01.version);
 
@@ -373,19 +397,83 @@ describe('/stages', () => {
 
 			expect(submission).to.not.be.null;
 			expect(submission.name).to.equal('satos');
-			expect(submission.score).to.equal(10000);
+			expect(submission.score).to.equal(validBoardScore);
+		});
+
+		it('creates new submission data with right score calculated by server', async () => {
+			const res = await chai.request(app).post('/stages/wire01/submissions').send({
+				name: 'satos',
+				board: validBoard,
+				score: validBoardScore + 10000,
+			});
+			expect(res).to.have.status(200);
+			expect(res).to.be.json;
+			expect(res.body.name).to.equal('satos');
+			expect(res.body.score).to.equal(validBoardScore);
+			expect(res.body.blocks).to.equal(3);
+			expect(res.body.version).to.equal(wire01.version);
+
+			const submission = await Submissions.findOne({
+				order: [
+					['createdAt', 'DESC'],
+				],
+			});
+
+			expect(submission).to.not.be.null;
+			expect(submission.name).to.equal('satos');
+			expect(submission.score).to.equal(validBoardScore);
 		});
 
 		it('reports error when the submission with higher score is existing', async () => {
 			await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'hakatashi',
 				board: validBoard,
+				score: validBoardScore,
 			});
 
 			try {
 				await chai.request(app).post('/stages/wire01/submissions').send({
 					name: 'hakatashi',
 					board: lowerScoreBoard,
+					score: lowerScoreBoardScore,
+				});
+				expect.fail();
+			} catch (res) {
+				expect(res).to.have.status(400);
+			}
+		});
+
+		it('omits calculting score and reports error when lower score than existing submission was proposed by client', async () => {
+			await chai.request(app).post('/stages/wire01/submissions').send({
+				name: 'hakatashi',
+				board: lowerScoreBoard,
+				score: lowerScoreBoardScore,
+			});
+
+			try {
+				await chai.request(app).post('/stages/wire01/submissions').send({
+					name: 'hakatashi',
+					board: validBoard,
+					score: lowerScoreBoardScore,
+				});
+				expect.fail();
+			} catch (res) {
+				expect(res).to.have.status(400);
+			}
+		});
+
+		it('reports error when the submission with higher score is existing, regardless of proposed score by client', async () => {
+			await chai.request(app).post('/stages/wire01/submissions').send({
+				name: 'hakatashi',
+				board: validBoard,
+				score: validBoardScore,
+			});
+
+			try {
+				await chai.request(app).post('/stages/wire01/submissions').send({
+					name: 'hakatashi',
+					board: lowerScoreBoard,
+					score: validBoardScore,
 				});
 				expect.fail();
 			} catch (res) {
@@ -398,6 +486,7 @@ describe('/stages', () => {
 				await chai.request(app).post('/stages/wire01/submissions').send({
 					name: '',
 					board: validBoard,
+					score: validBoardScore,
 				});
 				expect.fail();
 			} catch (res) {
@@ -409,16 +498,18 @@ describe('/stages', () => {
 			await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'kurgm',
 				board: lowerScoreBoard,
+				score: lowerScoreBoardScore,
 			});
 
 			const res = await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'kurgm',
 				board: validBoard,
+				score: validBoardScore,
 			});
 
 			expect(res).to.have.status(200);
 			expect(res).to.be.json;
-			expect(res.body.score).to.equal(10000);
+			expect(res.body.score).to.equal(validBoardScore);
 			expect(res.body.blocks).to.equal(3);
 
 			const submissions = await Submissions.findAll({
@@ -428,7 +519,7 @@ describe('/stages', () => {
 			});
 
 			expect(submissions).to.have.length(1);
-			expect(submissions[0].score).to.equal(10000);
+			expect(submissions[0].score).to.equal(validBoardScore);
 			expect(submissions[0].blocks).to.equal(3);
 		});
 
@@ -436,7 +527,7 @@ describe('/stages', () => {
 			await Submissions.create({
 				name: 'cookies',
 				board: JSON.stringify(validBoard),
-				score: 10000,
+				score: validBoardScore,
 				blocks: 3,
 				clocks: 3,
 				version: 1,
@@ -446,11 +537,12 @@ describe('/stages', () => {
 			const res = await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'cookies',
 				board: lowerScoreBoard,
+				score: lowerScoreBoardScore,
 			});
 
 			expect(res).to.have.status(200);
 			expect(res).to.be.json;
-			expect(res.body.score).to.be.below(10000);
+			expect(res.body.score).to.be.below(validBoardScore);
 			expect(res.body.blocks).to.equal(4);
 
 			const submissions = await Submissions.findAll({
@@ -460,7 +552,7 @@ describe('/stages', () => {
 			});
 
 			expect(submissions).to.have.length(1);
-			expect(submissions[0].score).to.be.below(10000);
+			expect(submissions[0].score).to.be.below(validBoardScore);
 			expect(submissions[0].blocks).to.equal(4);
 		});
 
@@ -469,7 +561,7 @@ describe('/stages', () => {
 				slackMock.send = ({text, attachments}) => {
 					try {
 						expect(text).to.include('kurgm');
-						expect(text).to.include('10000');
+						expect(text).to.include(String(validBoardScore));
 						expect(attachments).to.have.lengthOf(1);
 						resolve();
 					} catch (error) {
@@ -481,6 +573,7 @@ describe('/stages', () => {
 			await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'kurgm',
 				board: validBoard,
+				score: validBoardScore,
 			});
 
 			await promise;
@@ -491,7 +584,7 @@ describe('/stages', () => {
 				twitterMock.tweet = ({status}) => {
 					try {
 						expect(status).to.include('kurgm');
-						expect(status).to.include('10000');
+						expect(status).to.include(String(validBoardScore));
 						resolve();
 					} catch (error) {
 						reject(error);
@@ -502,6 +595,7 @@ describe('/stages', () => {
 			await chai.request(app).post('/stages/wire01/submissions').send({
 				name: 'kurgm',
 				board: validBoard,
+				score: validBoardScore,
 			});
 
 			await promise;

--- a/api/test/routes/stages.js
+++ b/api/test/routes/stages.js
@@ -325,7 +325,7 @@ describe('/stages', () => {
 		});
 
 		before(async () => {
-			expect(validBoardScore).to.equal(10000);
+			await expect(validBoardScore).to.equal(10000);
 		});
 
 		beforeEach(async () => {

--- a/lib/game.js
+++ b/lib/game.js
@@ -3,8 +3,6 @@
 const $ = require('jquery');
 const qs = require('querystring');
 const Stage = require('./stage');
-const {wait} = require('./util');
-const {calculateScore} = require('./validator');
 
 class Game {
 	constructor(configs) {
@@ -93,7 +91,6 @@ class Game {
 		this.currentStage = new Stage({
 			config: this.configs[index],
 			onClickExit: this.exitStage,
-			onAnswer: this.answer,
 		});
 		this.stageIndex = index;
 		$('.screens').addClass('gaming');
@@ -106,55 +103,6 @@ class Game {
 		if (this.currentStage.config.modal) {
 			this.showModal(this.currentStage.config.modal);
 		}
-	}
-
-	// TODO: this method should be implemented in Stage
-	answer = () => {
-		const blocks = this.currentStage.boardComponent.getWeighedBlockCount();
-		const clocks = this.currentStage.maxClock;
-
-		const score = calculateScore({blocks, clocks, stage: this.currentStage.config});
-
-		$('.result .tweet').attr('href', `https://twitter.com/intent/tweet?${qs.stringify({
-			text: `MNEMO「${this.currentStage.config.title}」ステージを ${score} 点でクリアしました！`,
-			url: 'https://mnemo.pro/',
-			hashtags: 'MNEMO',
-			related: 'tsg_ut:MNEMOを開発している東京大学のサークル',
-		})}`);
-
-		ga('send', 'event', 'stage', 'clear stage', this.currentStage.config.title, score);
-
-		$('.result').show();
-
-		const waitTime = $.fx.off ? 0 : 1200;
-
-		wait(waitTime).then(() => (
-			$({value: 0}).animate({value: 1}, {
-				duration: 500,
-				easing: 'linear',
-				step: (value) => {
-					$('.result .clocks').text(Math.floor(clocks * value));
-					$('.result .blocks').text(Math.floor(blocks * value));
-				},
-			}).promise()
-		)).then(() => {
-			$('.result .clocks').text(clocks);
-			$('.result .blocks').text(blocks);
-		});
-
-		const scoreWaitTime = $.fx.off ? 0 : 1400;
-
-		wait(scoreWaitTime).then(() => (
-			$({value: 0}).animate({value: 1}, {
-				duration: 2000,
-				easing: 'linear',
-				step: (value) => {
-					$('.result .score-value').text(Math.min(score, Math.floor(10000 * value)));
-				},
-			}).promise()
-		)).then(() => {
-			$('.result .score-value').text(score);
-		});
 	}
 
 	nextStage() {

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -4,17 +4,18 @@ const $ = require('jquery');
 const assert = require('assert');
 const React = require('react');
 const ReactDOM = require('react-dom');
+const qs = require('querystring');
 
 const BoardComponent = require('./board-component.jsx');
 const PanelComponent = require('./panel-component.jsx');
+const {calculateScore} = require('./validator');
 const api = require('./api');
-const {normalizeStageInput, translateDateFromUnixTime} = require('./util');
+const {normalizeStageInput, translateDateFromUnixTime, wait} = require('./util');
 
 class Stage {
-	constructor({config, onClickExit, onAnswer}) {
+	constructor({config, onClickExit}) {
 		this.config = Object.assign({}, config);
 		this.onClickExit = onClickExit;
-		this.onAnswer = onAnswer;
 
 		this.caseIndex = 0;
 		this.maxClock = 0;
@@ -429,7 +430,7 @@ class Stage {
 				this.$stage.find('button.stop').hide();
 				this.$stage.find('button.execute').show();
 				this.resetResults();
-				this.onAnswer();
+				this.answer();
 			} else {
 				this.caseIndex++;
 				this.executeCase();
@@ -458,6 +459,54 @@ class Stage {
 		$clockLimit.show();
 
 		this.handleHalt({force: true});
+	}
+
+	answer = () => {
+		const blocks = this.boardComponent.getWeighedBlockCount();
+		const clocks = this.maxClock;
+
+		const score = calculateScore({blocks, clocks, stage: this.config});
+
+		$('.result .tweet').attr('href', `https://twitter.com/intent/tweet?${qs.stringify({
+			text: `MNEMO「${this.config.title}」ステージを ${score} 点でクリアしました！`,
+			url: 'https://mnemo.pro/',
+			hashtags: 'MNEMO',
+			related: 'tsg_ut:MNEMOを開発している東京大学のサークル',
+		})}`);
+
+		ga('send', 'event', 'stage', 'clear stage', this.config.title, score);
+
+		$('.result').show();
+
+		const waitTime = $.fx.off ? 0 : 1200;
+
+		wait(waitTime).then(() => (
+			$({value: 0}).animate({value: 1}, {
+				duration: 500,
+				easing: 'linear',
+				step: (value) => {
+					$('.result .clocks').text(Math.floor(clocks * value));
+					$('.result .blocks').text(Math.floor(blocks * value));
+				},
+			}).promise()
+		)).then(() => {
+			$('.result .clocks').text(clocks);
+			$('.result .blocks').text(blocks);
+		});
+
+		const scoreWaitTime = $.fx.off ? 0 : 1400;
+
+		wait(scoreWaitTime).then(() => (
+			$({value: 0}).animate({value: 1}, {
+				duration: 2000,
+				easing: 'linear',
+				step: (value) => {
+					$('.result .score-value').text(Math.min(score, Math.floor(10000 * value)));
+				},
+			}).promise()
+		)).then(() => {
+			$('.result .score-value').text(score);
+		});
 	}
 }
 

--- a/lib/stage.js
+++ b/lib/stage.js
@@ -311,9 +311,14 @@ class Stage {
 
 		$(event.target).attr('disabled', true);
 
+		const blocks = this.boardComponent.getWeighedBlockCount();
+		const clocks = this.maxClock;
+		const score = calculateScore({blocks, clocks, stage: this.config});
+
 		const data = await api.post(`/stages/${this.config.name}/submissions`, {
 			name,
 			board: this.boardComponent.getBoardData(),
+			score,
 		});
 		const registrationDuration = Date.now() - registrationStartTime;
 


### PR DESCRIPTION
close #225 

```
const stageDatum = stageData.find((s) => s.name === stageName);
```
がundefinedでないのに、DBからとってきたはずのstageがnullになるのは、もう500だよね。

一応proposedScoreがbodyに無くても無駄にvalidateされるだけでエラーにはしていない（つもり、テストしてない）

Game#answerのとこにTODOでStageに移したいってあったので移した。
1位を取ったときのSlack通知のsurroundingSubmissionsがおかしくなる現象についても、多分治ったつもり。