### PR TITLE
remove resolution for webpack-sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,8 +135,5 @@
     "request": "^2.81.0",
     "seedrandom": "^2.4.2",
     "sequelize": "^4.22.14"
-  },
-  "resolutions": {
-    "webpack-sources": "1.0.1"
   }
 }


### PR DESCRIPTION
僕も忘れましたが blameを見るとこのresolutionsは #392 で追加されたっぽいです。
見てみるとテストが落ちていたのを回避するためのものっぽいので、
テスト通ったらresolutions解除していいんじゃないんでしょうか。

#392 には1.0.2の具合が悪いと書いてあり、最新は1.1.0っぽいですね